### PR TITLE
paged atom feed iterator: add license header

### DIFF
--- a/gedcomx-rs-client/src/main/java/org/gedcomx/rs/client/util/PagedFeedIterator.java
+++ b/gedcomx-rs-client/src/main/java/org/gedcomx/rs/client/util/PagedFeedIterator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright Intellectual Reserve, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gedcomx.rs.client.util;
 
 import com.sun.jersey.api.client.Client;

--- a/gedcomx-rs-client/src/test/java/org/gedcomx/rs/client/util/PagedFeedIteratorTest.java
+++ b/gedcomx-rs-client/src/test/java/org/gedcomx/rs/client/util/PagedFeedIteratorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright Intellectual Reserve, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gedcomx.rs.client.util;
 
 import org.gedcomx.atom.Feed;


### PR DESCRIPTION
I broke the build. :cry: I failed to compile from the command line and only relied on IntelliJ. I've confirmed a successful full build with this patch.
