### PR TITLE
DocMap convenience utility class

### DIFF
--- a/gedcomx-model/src/main/java/org/gedcomx/util/DocMap.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/util/DocMap.java
@@ -5,6 +5,8 @@ import org.gedcomx.agent.Agent;
 import org.gedcomx.common.URI;
 import org.gedcomx.conclusion.Identifier;
 import org.gedcomx.conclusion.Person;
+import org.gedcomx.conclusion.PlaceDescription;
+import org.gedcomx.conclusion.PlaceReference;
 import org.gedcomx.records.RecordDescriptor;
 import org.gedcomx.source.SourceDescription;
 import org.gedcomx.source.SourceReference;
@@ -28,6 +30,7 @@ public class DocMap {
   private Map<String, Person> personMap;
   private Map<String, RecordDescriptor> recordDescriptorMap;
   private Map<String, Agent> agentMap;
+  private Map<String, PlaceDescription> placeMap;
 
   /**
    * Constructor. Create an object that allows convenient lookup of things in a GedcomX document.
@@ -47,6 +50,7 @@ public class DocMap {
     personMap = getPersonMap(doc);
     recordDescriptorMap = getRecordDescriptorMap(doc);
     agentMap = getAgentMap(doc);
+    placeMap = getPlaceMap(doc);
     mainSourceDescription = getSourceDescription(doc.getDescriptionRef());
   }
 
@@ -164,6 +168,32 @@ public class DocMap {
     return agentId == null ? null : getAgent(agentId.toString());
   }
 
+  /**
+   * Find the PlaceDescription with the given local id (or "#" + local id) or the given URI.
+   * @param idOrUri - local id (with or without "#") or full identifier URI of a PlaceDescription.
+   * @return PlaceDescription object with the given local id or URI.
+   */
+  public PlaceDescription getPlaceDescription(String idOrUri) {
+    return idOrUri == null ? null : placeMap.get(idOrUri);
+  }
+
+  /**
+   * Find the PlaceDescription with the given local id (or "#" + local id) or the given URI.
+   * @param placeDescriptionUri - local id (with or without "#") or full identifier URI of a PlaceDescription.
+   * @return PlaceDescription object with the given local id or URI.
+   */
+  public PlaceDescription getPlaceDescription(URI placeDescriptionUri) {
+    return placeDescriptionUri == null ? null : getPlaceDescription(placeDescriptionUri.toString());
+  }
+
+  /**
+   * Find the PlaceDescription with the given PlaceReference.
+   * @param placeReference - PlaceReference that contains the (probably local) id of a PlaceDescription.
+   * @return PlaceDescription object with the given local id or URI.
+   */
+  public PlaceDescription getPlaceDescription(PlaceReference placeReference) {
+    return placeReference == null ? null : getPlaceDescription(placeReference.getDescriptionRef());
+  }
 
   /**
    * Create a map of id (and "#" + id) and all identifier URI strings to SourceDescription with that ID,
@@ -244,6 +274,30 @@ public class DocMap {
       for (RecordDescriptor recordDescriptor : doc.getRecordDescriptors()) {
         map.put(recordDescriptor.getId(), recordDescriptor);
         map.put("#" + recordDescriptor.getId(), recordDescriptor);
+      }
+    }
+    return map;
+  }
+
+  /**
+   * Create a map of local id (and "#" + id) and identifier URIs to the PlaceDescription that has that id or URL.
+   * If there are no place descriptions, an empty (but non-null) map is returned.
+   * @param doc - document to find place descriptions for
+   * @return Map of local id (and "#" + id) and URI string to each PlaceDescription in the doc.
+   */
+  public static Map<String, PlaceDescription> getPlaceMap(Gedcomx doc) {
+    Map<String, PlaceDescription> map = new HashMap<String, PlaceDescription>();
+    if (doc.getPlaces() != null) {
+      for (PlaceDescription placeDescription : doc.getPlaces()) {
+        map.put(placeDescription.getId(), placeDescription);
+        map.put("#" + placeDescription.getId(), placeDescription);
+        if (placeDescription.getIdentifiers() != null) {
+          for (Identifier identifier : placeDescription.getIdentifiers()) {
+            if (identifier.getValue() != null) {
+              map.put(identifier.getValue().toString(), placeDescription);
+            }
+          }
+        }
       }
     }
     return map;

--- a/gedcomx-model/src/test/java/org/gedcomx/util/TestDocMap.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/util/TestDocMap.java
@@ -6,11 +6,11 @@ import junit.framework.TestSuite;
 import org.gedcomx.Gedcomx;
 import org.gedcomx.agent.Agent;
 import org.gedcomx.common.URI;
-import org.gedcomx.conclusion.Identifier;
-import org.gedcomx.conclusion.Person;
+import org.gedcomx.conclusion.*;
 import org.gedcomx.records.RecordDescriptor;
 import org.gedcomx.source.SourceDescription;
 import org.gedcomx.source.SourceReference;
+import org.gedcomx.types.FactType;
 import org.gedcomx.types.IdentifierType;
 
 import java.util.Arrays;
@@ -30,6 +30,19 @@ public class TestDocMap extends TestCase {
     p1.addIdentifier(new Identifier(new URI("http://test.com/person1"), IdentifierType.Primary));
     // Alternate id for the same person resource.
     p1.addIdentifier(new Identifier(new URI("http://alternate.com/oldPerson1"), null));
+
+    PlaceDescription place = new PlaceDescription();
+    place.setId("place1");
+    place.addIdentifier(new Identifier(new URI("http://placedepot.com/places/1"), IdentifierType.Primary));
+    doc.addPlace(place);
+
+    PlaceReference placeReference = new PlaceReference();
+    placeReference.setDescriptionRef(new URI("#place1"));
+    Date date = new Date();
+    date.setOriginal("12 June 1874");
+    Fact fact = new Fact(FactType.Birth, date, placeReference);
+    p1.addFact(fact);
+
     doc.addPerson(p1);
 
     SourceDescription sd1 = new SourceDescription();
@@ -85,6 +98,9 @@ public class TestDocMap extends TestCase {
     assertEquals("rd1", docMap.getRecordDescriptor("https://whatever.com/collections/12345#rd1").getId());
     assertEquals("sd1", docMap.getMainSourceDescription().getId());
     assertEquals("p1", docMap.getMainPerson().getId());
+    assertEquals("place1", docMap.getPlaceDescription(docMap.getPerson("p1").getFacts().get(0).getPlace()).getId());
+    assertEquals("place1", docMap.getPlaceDescription(docMap.getPerson("p1").getFacts().get(0).getPlace().getDescriptionRef()).getId());
+    assertEquals("place1", docMap.getPlaceDescription(docMap.getPerson("p1").getFacts().get(0).getPlace().getDescriptionRef().toString()).getId());
   }
 
 }


### PR DESCRIPTION
The DocMap utility class simplifies working with GedcomX documents by making it easy to look up a person, source description, agent, place description or record descriptor by local id, "#" + local id, URI, SourceReference or PlaceReference.
