### PR TITLE
Added RecordSetWriter/Iterator, FieldMap

### DIFF
--- a/gedcomx-model/src/main/java/org/gedcomx/util/CleanXMLStreamWriter.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/util/CleanXMLStreamWriter.java
@@ -1,0 +1,216 @@
+package org.gedcomx.util;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * Delegating {@link XMLStreamWriter} that filters out UTF-8 characters that
+ * are illegal in XML, replacing them with a
+ *
+ * @author Erik van Zijst (small change by Lennart Schedin, and
+ *         isLegalXmlCharacter() expanded to XML 1.0 spec by Randy Wilson)
+ */
+public class CleanXMLStreamWriter implements XMLStreamWriter {
+
+  private final XMLStreamWriter writer;
+  // Unicode "REPLACEMENT_CHARACTER" (looks like a black diamond with a white question mark in the middle).
+  public static final char REPLACEMENT_CHARACTER = '\uFFFD';
+
+  public CleanXMLStreamWriter(XMLStreamWriter writer) {
+    if (null == writer) {
+      throw new IllegalArgumentException("null");
+    }
+    else {
+      this.writer = writer;
+    }
+  }
+
+  /**
+   * Substitutes all illegal characters in the given string by the value of
+   * {@link CleanXMLStreamWriter#REPLACEMENT_CHARACTER}.  If no illegal characters
+   * were found, no copy is made and the given string is returned.
+   *
+   * @param string the string
+   * @return same string, if not illegal characters detected;
+   *         otherwise, string with illegal characters replaced with {@link CleanXMLStreamWriter#REPLACEMENT_CHARACTER}
+   */
+  private String escapeCharacters(String string) {
+
+    char[] copy = null;
+    boolean copied = false;
+    for (int i = 0; i < string.length(); i++) {
+      if (!isLegalXmlCharacter(string.charAt(i))) {
+        if (!copied) {
+          copy = string.toCharArray();
+          copied = true;
+        }
+        copy[i] = REPLACEMENT_CHARACTER;
+      }
+    }
+    return copied ? new String(copy) : string;
+  }
+
+  public void writeStartElement(String s) throws XMLStreamException {
+    writer.writeStartElement(s);
+  }
+
+  public void writeStartElement(String s, String s1) throws XMLStreamException {
+    writer.writeStartElement(s, s1);
+  }
+
+  public void writeStartElement(String s, String s1, String s2)
+          throws XMLStreamException {
+    writer.writeStartElement(s, s1, s2);
+  }
+
+  public void writeEmptyElement(String s, String s1) throws XMLStreamException {
+    writer.writeEmptyElement(s, s1);
+  }
+
+  public void writeEmptyElement(String s, String s1, String s2)
+          throws XMLStreamException {
+    writer.writeEmptyElement(s, s1, s2);
+  }
+
+  public void writeEmptyElement(String s) throws XMLStreamException {
+    writer.writeEmptyElement(s);
+  }
+
+  public void writeEndElement() throws XMLStreamException {
+    writer.writeEndElement();
+  }
+
+  public void writeEndDocument() throws XMLStreamException {
+    writer.writeEndDocument();
+  }
+
+  public void close() throws XMLStreamException {
+    writer.close();
+  }
+
+  public void flush() throws XMLStreamException {
+    writer.flush();
+  }
+
+  public void writeAttribute(String localName, String value) throws XMLStreamException {
+    writer.writeAttribute(localName, escapeCharacters(value));
+  }
+
+  public void writeAttribute(String prefix, String namespaceUri, String localName, String value)
+          throws XMLStreamException {
+    writer.writeAttribute(prefix, namespaceUri, localName, escapeCharacters(value));
+  }
+
+  public void writeAttribute(String namespaceUri, String localName, String value)
+          throws XMLStreamException {
+    writer.writeAttribute(namespaceUri, localName, escapeCharacters(value));
+  }
+
+  public void writeNamespace(String s, String s1) throws XMLStreamException {
+    writer.writeNamespace(s, s1);
+  }
+
+  public void writeDefaultNamespace(String s) throws XMLStreamException {
+    writer.writeDefaultNamespace(s);
+  }
+
+  public void writeComment(String s) throws XMLStreamException {
+    writer.writeComment(s);
+  }
+
+  public void writeProcessingInstruction(String s) throws XMLStreamException {
+    writer.writeProcessingInstruction(s);
+  }
+
+  public void writeProcessingInstruction(String s, String s1)
+          throws XMLStreamException {
+    writer.writeProcessingInstruction(s, s1);
+  }
+
+  public void writeCData(String s) throws XMLStreamException {
+    writer.writeCData(escapeCharacters(s));
+  }
+
+  public void writeDTD(String s) throws XMLStreamException {
+    writer.writeDTD(s);
+  }
+
+  public void writeEntityRef(String s) throws XMLStreamException {
+    writer.writeEntityRef(s);
+  }
+
+  public void writeStartDocument() throws XMLStreamException {
+    writer.writeStartDocument();
+  }
+
+  public void writeStartDocument(String s) throws XMLStreamException {
+    writer.writeStartDocument(s);
+  }
+
+  public void writeStartDocument(String s, String s1)
+          throws XMLStreamException {
+    writer.writeStartDocument(s, s1);
+  }
+
+  public void writeCharacters(String s) throws XMLStreamException {
+    writer.writeCharacters(escapeCharacters(s));
+  }
+
+  public void writeCharacters(char[] chars, int start, int len)
+          throws XMLStreamException {
+    writer.writeCharacters(escapeCharacters(new String(chars, start, len)));
+  }
+
+  public String getPrefix(String s) throws XMLStreamException {
+    return writer.getPrefix(s);
+  }
+
+  public void setPrefix(String s, String s1) throws XMLStreamException {
+    writer.setPrefix(s, s1);
+  }
+
+  public void setDefaultNamespace(String s) throws XMLStreamException {
+    writer.setDefaultNamespace(s);
+  }
+
+  public void setNamespaceContext(NamespaceContext namespaceContext)
+          throws XMLStreamException {
+    writer.setNamespaceContext(namespaceContext);
+  }
+
+  public NamespaceContext getNamespaceContext() {
+    return writer.getNamespaceContext();
+  }
+
+  public Object getProperty(String s) throws IllegalArgumentException {
+    return writer.getProperty(s);
+  }
+
+  /**
+   * Tell whether the given character is valid in an XML document.
+   *
+   * @param c - character
+   * @return true if valid in XML, false if it would make an XML invalid.
+   */
+  protected static boolean isLegalXmlCharacter(int c) {
+    /* From the XML 1.0 specifications document at http://www.w3.org/TR/REC-xml/#charsets:
+         Char :: = #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+      */
+    return (c >= 0x20 && c <= 0xD7FF) ||
+            (c >= 0xE000 && c <= 0xFFFD) ||
+            (c >= 0x10000 && c <= 0x10FFFF) ||
+            (c == 0x09 || c == 0x0A || c == 0x0D);
+    /* The XML spec also discouraged use of the following, though they were not forbidden,
+       because they were either control characters or permanently undefined Unicode characters:
+        [#x7F-#x84], [#x86-#x9F], [#xFDD0-#xFDEF],
+        [#x1FFFE-#x1FFFF], [#x2FFFE-#x2FFFF], [#x3FFFE-#x3FFFF],
+        [#x4FFFE-#x4FFFF], [#x5FFFE-#x5FFFF], [#x6FFFE-#x6FFFF],
+        [#x7FFFE-#x7FFFF], [#x8FFFE-#x8FFFF], [#x9FFFE-#x9FFFF],
+        [#xAFFFE-#xAFFFF], [#xBFFFE-#xBFFFF], [#xCFFFE-#xCFFFF],
+        [#xDFFFE-#xDFFFF], [#xEFFFE-#xEFFFF], [#xFFFFE-#xFFFFF],
+        [#x10FFFE-#x10FFFF].
+       Since they are not forbidden, however, this reader will not make the decision to get rid of them.
+     */
+  }
+}

--- a/gedcomx-model/src/main/java/org/gedcomx/util/DocMap.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/util/DocMap.java
@@ -40,6 +40,7 @@ import java.util.Map;
  * Time: 3:53 PM
  */
 public class DocMap {
+  private Gedcomx doc;
   private SourceDescription mainSourceDescription;
   private Map<String, SourceDescription> sourceDescriptionMap;
   private Map<String, Person> personMap;
@@ -61,12 +62,21 @@ public class DocMap {
    * @param doc - GedcomX document to rebuild maps for.
    */
   public void update(Gedcomx doc) {
+    this.doc = doc;
     sourceDescriptionMap = getSourceDescriptionMap(doc);
     personMap = getPersonMap(doc);
     recordDescriptorMap = getRecordDescriptorMap(doc);
     agentMap = getAgentMap(doc);
     placeMap = getPlaceMap(doc);
     mainSourceDescription = getSourceDescription(doc.getDescriptionRef());
+  }
+
+  /**
+   * Get the Gedcomx document that was used to create this DocMap.
+   * @return GedcomX document that was used to create this DocMap.
+   */
+  public Gedcomx getDocument() {
+    return doc;
   }
 
   /**

--- a/gedcomx-model/src/main/java/org/gedcomx/util/FieldMap.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/util/FieldMap.java
@@ -1,0 +1,414 @@
+package org.gedcomx.util;
+
+import org.gedcomx.Gedcomx;
+import org.gedcomx.common.ResourceReference;
+import org.gedcomx.common.TextValue;
+import org.gedcomx.common.URI;
+import org.gedcomx.conclusion.*;
+import org.gedcomx.records.*;
+import org.gedcomx.source.Coverage;
+import org.gedcomx.source.SourceDescription;
+import org.gedcomx.types.RecordType;
+
+import java.util.*;
+
+/**
+ * Class for helping to deal with connecting field values with record descriptors for historical records
+ *   and image browse data.
+ * Historical records have both structured data (persons with names, gender, facts; and relationships with facts)
+ *   and 'fields'. A field often represents what was actually stated within some area of text on a historical
+ *   document (or what was strongly implied by that document, such as the male gender of a father in a birth record).
+ * Each field has a list of field values, which can be of FieldValueType.Original, meaning what the document
+ *   originally said (or structurally implied); or FieldValueType.Interpreted, meaning that a user or system
+ *   interpreted. For example, a 'gender' field might have an original field value of "M", which, because it is
+ *   in a Mexican census, means "Mujer", which means "Female". So the "Interpreted" field value might say
+ *   "Mujer", or might say "Female"; or it is possible that both are included, since it is a list.
+ * These field values will be found within a Field of type "http://gedcomx.org/Gender", and that field will be
+ *   found inside of the gender inside of the person it applies to. That gender will have a conclusional 'type'
+ *   (e.g., "http://gedcomx.org/Female") that software will typically use.
+ * The 'structured data' of the record is typically used when dealing with what the record 'meant' or in displaying
+ *   genealogical data to be used in copying over to a conclusion tree.
+ * The 'fields' of a record are typically used when display what the record originally 'said', in order to help
+ *   communicate to a user some of the genealogical nuances that each record can have, including some that don't
+ *   translate directly into the standardized conclusional structure that GedcomX supports.
+ * Having structured data with embedded fields (plus a list of fields at the person, relationship and record level)
+ *   allows general-purpose genealogical use of 'what the record is telling us' (via the structure) as well as
+ *   preservation of the special-purpose nuances of a particular record type (via the fields).
+ *
+ * A GedcomX document that represents a historical record will often have a SourceDescription that has a
+ *   record 'descriptor' reference, which is the URL of a GedcomX document that represents the Collection that
+ *   the record is found in, along with a "#" and local id of the record descriptor withing that collection's
+ *   document, that describes the display labels to be used for displaying a field-value pair view of the
+ *   record's field data.
+ * This class takes two GedcomX documents: a record and its collection (or, equivalently, the DocMap for both)
+ *   and walks the structure of the record to find all of the field values, and builds the maps necessary to
+ *   find all the field labelIds, the localized display labels for each labelId, and the values for each labelId
+ *   found in the record. (Note that because a Field can have multiple FieldValues of the same type (original or
+ *   interpreted), then each labelId can map to a list of values).
+ * Also, Census records are different from other records in that each person in a census household can have the
+ *   same list of fields, so when displaying field values from census data, it must be done one person at a time.
+ *   Therefore, each record will either support getValues(labelId) [i.e., for non-census] or
+ *   getValues(person, labelId) [census], but not both.
+ * User: Randy Wilson
+ * Date: 7/31/2014
+ * Time: 11:07 AM
+ */
+public class FieldMap {
+  // DocMaps for the collection and record.
+  private DocMap collectionDocMap;
+  private DocMap recordDocMap;
+  // Main record descriptor for this record from this collection.
+  private RecordDescriptor recordDescriptor;
+  // Flag for whether this record was a census record (with person-specific fields) or not.
+  // A census collection can have the same field IDs over again for each person.
+  private boolean isCensus;
+  // Map of labelId -> FieldValueDescriptor for that label id.
+  private Map<String, FieldValueDescriptor> labelFieldValueDescriptorMap;
+
+  // map of labelId -> list of Strings that appeared in field values with that labelId.
+  private Map<String, List<String>> labelValueMap;
+  // map of Person -> labelId -> list of field value Strings (for census records).
+  // Includes a 'null' Person for record-level field values, if any.
+  private Map<Person, Map<String, List<String>>> personLabelValueMap;
+
+  /**
+   * Constructor for a collection and record GedcomX document.
+   * @param record - GedcomX document for a record (which is in the given collection).
+   * @param collection - GedcomX document for a collection (which contains the RecordDescriptor for the record).
+   */
+  public FieldMap(Gedcomx record, Gedcomx collection) {
+    this(new DocMap(record), new DocMap(collection));
+  }
+
+  /**
+   * Constructor using a DocMap for a collection and record. Use this constructor if you've already built a DocMap
+   *   for the record and/or collection.
+   * @param recordDocMap - DocMap for a GedcomX document for a record (which is in the given collection)
+   * @param collectionDocMap - DocMap for a GedcomX document for a collection (which contains the RecordDescriptor for the record).
+   */
+  public FieldMap(DocMap recordDocMap, DocMap collectionDocMap) {
+    this.collectionDocMap = collectionDocMap;
+    this.recordDocMap = recordDocMap;
+    recordDescriptor = getRecordDescriptor(collectionDocMap, recordDocMap);
+    labelFieldValueDescriptorMap = getLabelFieldValueDescriptorMap(recordDescriptor);
+    isCensus = isCensus(recordDocMap);
+    if (isCensus) {
+      personLabelValueMap = getPersonLabelValueMap(recordDocMap.getDocument());
+    }
+    else {
+      labelValueMap = getLabelValuesMap(getAllFields(recordDocMap.getDocument()));
+    }
+  }
+
+  /**
+   * Get the DocMap for the collection that the record is found in.
+   * @return DocMap for the collection that the record is found in.
+   */
+  public DocMap getCollectionDocMap() {
+    return collectionDocMap;
+  }
+
+  /**
+   * Get the DocMap for the record.
+   * @return DocMap for the record.
+   */
+  public DocMap getRecordDocMap() {
+    return recordDocMap;
+  }
+
+  /**
+   * Get the GedcomX document for the collection that the record is found in.
+   * @return GedcomX document for the collection that the record is found in.
+   */
+  public Gedcomx getCollection() {
+    return collectionDocMap.getDocument();
+  }
+
+  /**
+   * Get the GedcomX document for the record.
+   * @return GedcomX document for the record.
+   */
+  public Gedcomx getRecord() {
+    return collectionDocMap.getDocument();
+  }
+
+  /**
+   * Get the display label for the given labelId in the closest language available to the one given.
+   * @param labelId - labelId to get the display value for (e.g., "PR_NAME")
+   * @param language - Preferred language to get the display label in. null => use en-US.
+   * @return Display label to use for the labelId, or null if there is not one.
+   */
+  public String getDisplayLabel(String labelId, String language) {
+    FieldValueDescriptor fieldValueDescriptor = labelFieldValueDescriptorMap.get(labelId);
+    if (fieldValueDescriptor.getDisplayLabels() != null) {
+      TextValue bestValue = LocaleUtil.findClosestLocale(fieldValueDescriptor.getDisplayLabels(), new Locale(language));
+      return bestValue == null ? null : bestValue.getValue();
+    }
+    return null;
+  }
+
+  /**
+   * Get a list of values that had the given labelId in the record. Must be a non-census record, or else the person
+   *   must be specified.
+   * @param labelId - LabelId to get the values for
+   * @return List of values for the given labelId, or null if none.
+   */
+  public List<String> getValues(String labelId) {
+    if (isCensus) {
+      throw new IllegalArgumentException("Can't call getValues(labelId) on census collection. Use getValues(person, labelId) instead.");
+    }
+    return labelValueMap.get(labelId);
+  }
+
+  /**
+   * Get a list of values that had the given labelId in the record for the given person.
+   * Must be a census record.
+   * @param person - person to get values for (null => get record-level values for the given labelId, if any)
+   * @param labelId - LabelId to get the values for
+   * @return List of values for the given labelId, or null if none.
+   */
+  public List<String> getValues(Person person, String labelId) {
+    if (!isCensus) {
+      throw new IllegalArgumentException("Can't call getValues(person, labelId) on non-census collection");
+    }
+    Map<String, List<String>> labelValueMap = personLabelValueMap.get(person);
+    return labelValueMap == null ? null : labelValueMap.get(labelId);
+  }
+
+  /**
+   * Get a map of Person to labelId to list of Strings for field values that had that label ID within that person.
+   * Includes a null Person in the map if there were any record-level field values.
+   * @param record - Record to build map for.
+   * @return map of Person to labelId to list of field values.
+   */
+  private static Map<Person, Map<String, List<String>>> getPersonLabelValueMap(Gedcomx record) {
+    Map<Person, List<Field>> personFieldMap = getPersonFieldMap(record);
+    Map<Person, Map<String, List<String>>> personMap = new LinkedHashMap<Person, Map<String, List<String>>>();
+
+    for (Person person : personFieldMap.keySet()) {
+      personMap.put(person, getLabelValuesMap(personFieldMap.get(person)));
+    }
+    return personMap;
+  }
+
+  /**
+   * Get the RecordDescriptor that goes with this record.
+   * @return RecordDescriptor that goes with this record.
+   */
+  public RecordDescriptor getRecordDescriptor() {
+    return recordDescriptor;
+  }
+
+  /**
+   * Find the RecordDescriptor from the collection document that is referenced by the main source description
+   *   from the record document, i.e., find the record's record descriptor in the collection.
+   * @param collectionDocMap - DocMap for the collection GedcomX document.
+   * @param recordDocMap - DocMap for the record GedcomX document.
+   * @return Record's RecordDescriptor, or null if not found.
+   */
+  public static RecordDescriptor getRecordDescriptor(DocMap collectionDocMap, DocMap recordDocMap) {
+    ResourceReference ref = recordDocMap.getMainSourceDescription().getDescriptorRef();
+    if (ref != null && ref.getResource() != null) {
+      String uri = ref.getResource().toString();
+      if (uri != null) {
+        int pos = uri.indexOf("#");
+        if (pos > 0) {
+          return collectionDocMap.getRecordDescriptor(uri.substring(pos + 1));
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get a map of labelId to FieldValueDescriptor for that label id.
+   * @param recordDescriptor - RecordDescriptor to build the map from.
+   * @return Map of labelId to FieldValueDescriptor.
+   */
+  public static Map<String, FieldValueDescriptor> getLabelFieldValueDescriptorMap(RecordDescriptor recordDescriptor) {
+    if (recordDescriptor != null && recordDescriptor.getFields() != null) {
+      Map<String, FieldValueDescriptor> map = new LinkedHashMap<String, FieldValueDescriptor>();
+      for (FieldDescriptor fieldDescriptor : recordDescriptor.getFields()) {
+        if (fieldDescriptor.getValues() != null) {
+          for (FieldValueDescriptor fieldValueDescriptor : fieldDescriptor.getValues()) {
+            if (map.get(fieldValueDescriptor.getLabelId()) != null) {
+              throw new IllegalStateException("Multiple field value descriptors for label id '" + fieldValueDescriptor.getLabelId() + "'");
+            }
+            map.put(fieldValueDescriptor.getLabelId(), fieldValueDescriptor);
+          }
+        }
+      }
+      return map;
+    }
+    return null;
+  }
+
+  /**
+   * Get a map of Person to the list of Fields for that person.  A 'null' person is also
+   *   included if there are any record-level fields.
+   * @param record - record to get field map from
+   * @return map of Person (or null for record-level fields) to the list of fields for that person.
+   */
+  public static Map<Person, List<Field>> getPersonFieldMap(Gedcomx record) {
+    Map<Person, List<Field>> personFieldsMap = new LinkedHashMap<Person, List<Field>>();
+    addFields(record.getFields(), null, personFieldsMap);
+    if (record.getPersons() != null) {
+      for (Person person : record.getPersons()) {
+        addFields(person.getFields(), person, personFieldsMap);
+        if (person.getGender() != null) {
+          addFields(person.getGender().getFields(), person, personFieldsMap);
+        }
+        if (person.getNames() != null) {
+          for (Name name : person.getNames()) {
+            if (name.getNameForms() != null) {
+              for (NameForm nameForm : name.getNameForms()) {
+                addFields(nameForm.getFields(), person, personFieldsMap);
+                if (nameForm.getParts() != null) {
+                  for (NamePart namePart : nameForm.getParts()) {
+                    addFields(namePart.getFields(), person, personFieldsMap);
+                  }
+                }
+              }
+            }
+          }
+        }
+        if (person.getFacts() != null) {
+          for (Fact fact : person.getFacts()) {
+            addFields(fact.getFields(), person, personFieldsMap);
+            if (fact.getDate() != null) {
+              addFields(fact.getDate().getFields(), person, personFieldsMap);
+            }
+            if (fact.getPlace() != null) {
+              addFields(fact.getPlace().getFields(), person, personFieldsMap);
+            }
+          }
+        }
+      }
+    }
+    return personFieldsMap;
+  }
+
+  /**
+   * Create a list of all of the fields occurring in the given GedcomX record, including those found
+   *   within the various values.  Note that this is a flat list that can't distinguish between the
+   *   fields with the same label that belong to different persons, so only call when you're sure there
+   *   will be no duplicates (as with a non-census record or a mapping Template).
+   * @param record - GedcomX to get fields for.
+   * @return list of fields occurring in the GedcomX record.
+   */
+  public static List<Field> getAllFields(Gedcomx record) {
+    List<Field> fields = new ArrayList<Field>();
+    Map<Person, List<Field>> personFieldMap = getPersonFieldMap(record);
+    if (record.getPersons() != null) {
+      for (Person person : record.getPersons()) {
+        addFields(personFieldMap.get(person), fields);
+      }
+    }
+    // Add record-level fields.
+    addFields(personFieldMap.get(null), fields);
+    return fields;
+  }
+
+
+
+
+  /**
+   * Get a map of labelId to values from all of the FieldValues that appear in the given list of Fields.
+   * If two FieldValues have the same labelId, then they are put into the same list.
+   * @param fields - list of Fields to look in for FieldValues.
+   * @return map of labelId to FieldValue values.
+   */
+  public static Map<String, List<String>> getLabelValuesMap(List<Field> fields) {
+    Map<String, List<String>> labelValueMap = new LinkedHashMap<String, List<String>>();
+    if (fields != null) {
+      for (Field field : fields) {
+        if (field.getValues() != null) {
+          for (FieldValue fieldValue : field.getValues()) {
+            List<String> values = labelValueMap.get(fieldValue.getLabelId());
+            if (values == null) {
+              values = new ArrayList<String>();
+              labelValueMap.put(fieldValue.getLabelId(), values);
+            }
+            values.add(fieldValue.getText());
+          }
+        }
+      }
+    }
+    return labelValueMap;
+  }
+
+  /**
+   * Add the given list of Fields (if not empty or null) to the list of fields for the given person,
+   *   in the personFieldMap.  If there is no list for the given person, then one is created and
+   *   added to the map.
+   * @param listToAdd - List of Fields to add (or null if none).
+   * @param person - Person to whose list the fields should be added (null => record-level fields)
+   * @param personFieldMap - Map to add the list of fields to.
+   */
+  private static void addFields(List<Field> listToAdd, Person person, Map<Person, List<Field>> personFieldMap) {
+    if (listToAdd != null) {
+      List<Field> fieldList = personFieldMap.get(person);
+      if (fieldList == null) {
+        fieldList = new ArrayList<Field>();
+        personFieldMap.put(person, fieldList);
+      }
+      fieldList.addAll(listToAdd);
+    }
+  }
+
+  /**
+   * Add the given list of fields to the master list.
+   * @param listToAdd - List of fields to add.
+   * @param allFields - List to add the fields to.
+   */
+  private static void addFields(List<Field> listToAdd, List<Field> allFields) {
+    if (listToAdd != null) {
+      allFields.addAll(listToAdd);
+    }
+  }
+
+  /**
+   * Tell whether the given record is a Census record, i.e., if it has a SourceDescription with a Coverage with
+   *   a RecordType of Census.
+   * @param record - GedcomX record to examine
+   * @return true if this is a census record, false otherwise.
+   */
+  public static boolean isCensus(Gedcomx record) {
+    URI descriptionRef = record.getDescriptionRef();
+    if (descriptionRef != null) {
+      for (SourceDescription sourceDescription : record.getSourceDescriptions()) {
+        if (("#" + sourceDescription.getId()).equals(descriptionRef.toString())) {
+          return isCensus(sourceDescription);
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Tell whether the record with the given DocMap is a Census record, i.e., if it has a SourceDescription with a Coverage with
+   *   a RecordType of Census.
+   * @param recordDocMap - DocMap of the GedcomX record to examine
+   * @return true if this is a census record, false otherwise.
+   */
+  public static boolean isCensus(DocMap recordDocMap) {
+    return isCensus(recordDocMap.getMainSourceDescription());
+  }
+
+  /**
+   * Tell whether the given SourceDescription has 'coverage' with a RecordType of census.
+   * @param sourceDescription - SourceDescription to examine for coverage.
+   * @return true if this is a census record, false otherwise.
+   */
+  public static boolean isCensus(SourceDescription sourceDescription) {
+    if (sourceDescription != null && sourceDescription.getCoverage() != null) {
+      for (Coverage coverage : sourceDescription.getCoverage()) {
+        if (coverage.getKnownRecordType() == RecordType.Census) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+}

--- a/gedcomx-model/src/main/java/org/gedcomx/util/LocaleUtil.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/util/LocaleUtil.java
@@ -1,0 +1,135 @@
+package org.gedcomx.util;
+
+import org.gedcomx.common.TextValue;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Class for helping to choose the "best" locale that is available, given a preferred locale (e.g., that is being
+ *   used by a particular user at a web site) and a default locale (e.g., English).
+ * User: Randy Wilson
+ * Date: 7/31/2014
+ * Time: 11:44 AM
+ */
+public class LocaleUtil {
+  /**
+   * Return the textValue whose language is closest the localeToMatch.
+   * @param textValues - Collection of TextValues, each with a value and a language.
+   * @param localeToMatch - Preferred locale to match against.
+   * @return TextValue in the given collection that is closest to the given locale; or null if there are no values.
+   */
+  public static TextValue findClosestLocale(Collection<TextValue> textValues, Locale localeToMatch) {
+    return findClosestLocale(textValues, localeToMatch, Locale.ENGLISH);
+  }
+
+  /**
+   * Return the textValue whose language is closest the localeToMatch.
+   * @param textValues - Collection of TextValues, each with a value and a language.
+   * @param localeToMatch - Preferred locale to match against.
+   * @param defaultLocale - Default locale to match against, if none are close to the preferred locale.
+   * @return TextValue in the given collection that is closest to the given locale; or null if there are no values.
+   */
+  public static TextValue findClosestLocale(Collection<TextValue> textValues, Locale localeToMatch, Locale defaultLocale) {
+    if (textValues != null) {
+      TextValue bestTextValue = null;
+      Locale bestLocale = null;
+      for (TextValue textValue : textValues) {
+        Locale locale = Locale.forLanguageTag(textValue.getLang());
+        if (bestTextValue == null || LocaleUtil.isBetterLocaleMatch(localeToMatch, locale, bestLocale, defaultLocale)) {
+          bestTextValue = textValue;
+          bestLocale = locale;
+        }
+      }
+      return bestTextValue;
+    }
+    return null;
+  }
+
+  public static Locale findClosestLocale(Set<Locale> locales, Locale localeToMatch) {
+    return findClosestLocale(locales, localeToMatch, Locale.ENGLISH);
+  }
+
+  public static Locale findClosestLocale(Set<Locale> locales, Locale localeToMatch, Locale defaultLocale) {
+    if (locales == null) {
+      return null;
+    }
+    if (defaultLocale == null) {
+      defaultLocale = Locale.getDefault();
+    }
+    if (localeToMatch == null) {
+      localeToMatch = defaultLocale;
+    }
+    Locale currentBest = null;
+    for (Locale locale : locales) {
+      if (locale.equals(localeToMatch)) {
+        return locale;
+      }
+      if (isBetterLocaleMatch(localeToMatch, locale, currentBest, defaultLocale)) {
+        currentBest = locale;
+      }
+    }
+    return currentBest;
+  }
+
+  /**
+   * Decide if the current locale is a better match to the preferred one than the 'best' one found so far.
+   * @param preferredLocale - The preferred locale that is being matched against.
+   * @param currentLocale - The current locale to check to see if it is closer to the preferred locale than the 'best' one so far.
+   * @param bestLocale - The best locale (i.e., closest to 'preferredLocale') found so far, or null if this is the first one.
+   * @param defaultLocale - Default locale to
+   * @return true if 'currentLocale' is closer to preferredLocale (or, if best and current are both too far, if it is
+   *         closer to defaultLocale) than 'best'; false otherwise.
+   */
+  private static boolean isBetterLocaleMatch(Locale preferredLocale, Locale currentLocale, Locale bestLocale, Locale defaultLocale) {
+    if (bestLocale == null) {
+      // pick the first one you come to
+      return true;
+    }
+    int currentMatch = matchCount(preferredLocale, currentLocale);
+    int bestMatch = matchCount(preferredLocale, bestLocale);
+    // if the new locale is better than current best we have
+    if (currentMatch > bestMatch) {
+      // take the new one
+      return true;
+    }
+    // if neither the current best, nor the current value match the preferred locale at all...
+    // (meaning that the preferred locale is something other than the default, and we don't have any string in that locale at all)
+    // pick the one that is closest to the default
+    return bestMatch == 0 && !defaultLocale.equals(preferredLocale) && matchCount(defaultLocale, currentLocale) > matchCount(defaultLocale, bestLocale);
+  }
+
+  /**
+   * Get a score for "nearness" between two locales
+   *
+   * @param locale1 the first locale
+   * @param locale2 the second locale
+   * @return the score (10 for each match on part, 1 for mismatched parts when either one is an empty string, so "en" matches "en_US" better than "en_CA"
+   */
+  private static int matchCount(Locale locale1, Locale locale2) {
+    int value = 0;
+    String l1 = locale1.getLanguage();
+    String l2 = locale2.getLanguage();
+    if (l1.equals(l2)) {
+      value += 10;
+      String c1 = locale1.getCountry();
+      String c2 = locale2.getCountry();
+      if (c1.equals(c2)) {
+        value += 10;
+        String v1 = locale1.getVariant();
+        String v2 = locale2.getVariant();
+        if (v1.equals(v2)) {
+          value += 10;
+        }
+        else if (v1.equals("") || v2.equals("")) {
+          value++;
+        }
+      }
+      else if (c1.equals("") || c2.equals("")) {
+        value++;
+      }
+    }
+    return value;
+  }
+}

--- a/gedcomx-model/src/main/java/org/gedcomx/util/RecordSetIterator.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/util/RecordSetIterator.java
@@ -1,0 +1,134 @@
+package org.gedcomx.util;
+
+import org.gedcomx.Gedcomx;
+import org.gedcomx.records.RecordSet;
+import org.gedcomx.rt.GedcomxConstants;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.*;
+import java.util.Iterator;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Class for iterating through the 'record' elements (GedcomX documents) in a RecordSet one at a time
+ *   from a stream (e.g., a gzipped byte array) without having to inflate all the records at once.
+ * User: Randy Wilson
+ * Date: 7/31/2014
+ * Time: 1:58 PM
+ */
+public class RecordSetIterator implements Iterator<Gedcomx> {
+  private static final QName recordName = new QName(GedcomxConstants.GEDCOMX_NAMESPACE, "record");
+  private static JAXBContext jaxbContext = null;
+  private BufferedReader reader;
+  private XMLStreamReader xmlStreamReader;
+  private Gedcomx nextRecord;
+  private Unmarshaller unmarshaller;
+
+  static {
+    try {
+      jaxbContext = JAXBContext.newInstance(RecordSet.class, Gedcomx.class);
+    }
+    catch (Exception ex) {
+      ex.printStackTrace();
+    }
+  }
+
+  /**
+   * Constructor for a record iterator that takes a filename of a RecordSet file and iterates through its record elements.
+   * @param filename - Filename to read a GedcomX RecordSet file from.
+   * @throws java.io.IOException
+   */
+  public RecordSetIterator(String filename) throws IOException {
+    this(filename.toLowerCase().endsWith(".gz") ? new GZIPInputStream(new FileInputStream(filename)) : new FileInputStream(filename));
+  }
+
+  public RecordSetIterator(InputStream inputStream, boolean isGzipped) throws IOException {
+    this(isGzipped ? new GZIPInputStream(inputStream) : inputStream);
+  }
+
+  /**
+   * Constructor for a record iterator that takes an InputStream of a RecordSet file and iterates through its record elements.
+   * @param inputStream - InputStream to read a GedcomX RecordSet file from.
+   * @throws IOException
+   */
+  public RecordSetIterator(InputStream inputStream) throws IOException {
+    this(new BufferedReader(new InputStreamReader(inputStream, "UTF-8")));
+  }
+
+  /**
+   * Constructor for a record iterator that takes a BufferedReader of a RecordSet file and iterates through its record elements.
+   * @param reader - BufferedReader to read a GedcomX RecordSet file from.
+   * @throws IOException
+   */
+  public RecordSetIterator(BufferedReader reader) throws IOException {
+    try {
+      this.reader = reader;
+      xmlStreamReader = XMLInputFactory.newFactory().createXMLStreamReader(reader);
+      unmarshaller = jaxbContext.createUnmarshaller();
+      prepareNext();
+    } catch (JAXBException e) {
+      throw new RuntimeException(e);
+    } catch (XMLStreamException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Tell whether the RecordIterator has another GedcomX record to return.
+   * @return true if there is another record to read; false otherwise.
+   */
+  synchronized public boolean hasNext() {
+    return nextRecord != null;
+  }
+
+  /**
+   * Prepare the next record to be retrieved.  Sets 'nextRecord' to the parsed record, if any, or null
+   *   if there are no more.  Consumes bytes from the xmlStreamReader.
+   * If there are no more records, then closes the reader and xmlStreamReader and sets them both to null.
+   * @throws XMLStreamException
+   * @throws JAXBException
+   */
+  synchronized private void prepareNext() throws XMLStreamException, JAXBException, IOException {
+    nextRecord = null;
+    while (xmlStreamReader.hasNext() && nextRecord == null) {
+      if (xmlStreamReader.isStartElement() && xmlStreamReader.getName().equals(recordName)) {
+        nextRecord = unmarshaller.unmarshal(xmlStreamReader, Gedcomx.class).getValue();
+      }
+      else {
+        xmlStreamReader.next();
+      }
+    }
+    if (nextRecord == null) {
+      xmlStreamReader.close();
+      xmlStreamReader = null;
+      reader.close();
+      reader = null;
+    }
+  }
+
+  synchronized public Gedcomx next() {
+    try {
+      if (nextRecord == null) {
+        return null;
+      }
+      Gedcomx record = nextRecord;
+      prepareNext();
+      return record;
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void remove() {
+    throw new NotImplementedException();
+  }
+
+}

--- a/gedcomx-model/src/main/java/org/gedcomx/util/RecordSetWriter.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/util/RecordSetWriter.java
@@ -1,0 +1,63 @@
+package org.gedcomx.util;
+
+import com.sun.xml.txw2.output.IndentingXMLStreamWriter;
+import org.gedcomx.Gedcomx;
+import org.gedcomx.records.RecordSet;
+import org.gedcomx.rt.GedcomxConstants;
+
+import javax.xml.bind.*;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Class for streaming a RecordSet to an OutputStream as records are being added.
+ * User: Randy Wilson
+ * Date: 12/4/13
+ */
+public class RecordSetWriter {
+  Marshaller marshaller;
+  private XMLStreamWriter xmlWriter;
+
+  // Stream to write data to
+  private OutputStream outputStream;
+
+  public RecordSetWriter(OutputStream outputStream) {
+    try {
+      marshaller = JAXBContext.newInstance(Gedcomx.class, RecordSet.class).createMarshaller();
+      marshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);
+
+      this.outputStream = outputStream;
+      // Use a CleanXMLStreamWriter to avoid illegal XML characters in the marshalled output, such as a vertical tab character.
+      xmlWriter = new CleanXMLStreamWriter(XMLOutputFactory.newFactory().createXMLStreamWriter(outputStream, "UTF-8"));
+      xmlWriter.setDefaultNamespace(GedcomxConstants.GEDCOMX_NAMESPACE);
+      xmlWriter = new IndentingXMLStreamWriter(xmlWriter);
+      xmlWriter.writeStartDocument();
+      xmlWriter.writeStartElement(GedcomxConstants.GEDCOMX_NAMESPACE, "records");
+      xmlWriter.writeNamespace("", GedcomxConstants.GEDCOMX_NAMESPACE);
+    } catch (XMLStreamException e) {
+      throw new RuntimeException(e);
+    } catch (PropertyException e) {
+      throw new RuntimeException(e);
+    } catch (JAXBException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void writeRecord(Gedcomx record) throws JAXBException {
+    marshaller.marshal(new JAXBElement<Gedcomx>(new QName(GedcomxConstants.GEDCOMX_NAMESPACE, "record"), Gedcomx.class, record), xmlWriter);
+  }
+
+  public void close() throws IOException {
+    try {
+      xmlWriter.writeEndElement();
+      xmlWriter.close();
+      outputStream.close();
+    } catch (XMLStreamException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/gedcomx-model/src/test/java/org/gedcomx/util/MarshalUtil.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/util/MarshalUtil.java
@@ -1,0 +1,106 @@
+package org.gedcomx.util;
+
+import org.gedcomx.Gedcomx;
+import org.gedcomx.records.RecordSet;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import java.io.*;
+
+/**
+ * Convenience class for converting a GedcomX document or RecordSet to and from XML.
+ * User: Randy Wilson
+ * Date: 7/31/2014
+ * Time: 2:17 PM
+ */
+public class MarshalUtil {
+  private static JAXBContext jxbc;
+
+  static {
+    try {
+      jxbc = JAXBContext.newInstance(org.gedcomx.Gedcomx.class, org.gedcomx.records.RecordSet.class);
+    }
+    catch (Exception ex) {
+      ex.printStackTrace();
+    }
+  }
+
+  private static Marshaller getMarshaller(boolean prettyFormat) throws JAXBException {
+    Marshaller m = jxbc.createMarshaller();
+    m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, prettyFormat);
+    m.setProperty("com.sun.xml.bind.indentString", "  ");
+    return m;
+  }
+
+  public static Unmarshaller createUnmarshaller() throws JAXBException {
+    return jxbc.createUnmarshaller();
+  }
+
+  /**
+   * Output a RecordSet to an OutputStream as XML
+   * @param outputStream - OutputStream to write the RecordSet to
+   * @param recordSet - RecordSet to write
+   * @param prettyFormat - flag for whether to use newlines and indentation in the output
+   * @throws JAXBException
+   * @throws java.io.IOException
+   */
+  public static void output(OutputStream outputStream, RecordSet recordSet, boolean prettyFormat) throws JAXBException, IOException {
+    getMarshaller(prettyFormat).marshal(recordSet, outputStream);
+  }
+
+  /**
+   * Output a Gedcomx document to an OutputStream as XML
+   * @param outputStream - OutputStream to write the record to
+   * @param doc - GedcomX document to write
+   * @param prettyFormat - flag for whether to use newlines and indentation in the output
+   * @throws JAXBException
+   * @throws IOException
+   */
+  public static void output(OutputStream outputStream, Gedcomx doc, boolean prettyFormat) throws JAXBException, IOException {
+    getMarshaller(prettyFormat).marshal(doc, outputStream);
+  }
+
+  /**
+   * Unmarshal a Gedcomx document from an InputStream
+   * @param inputStream - InputStream to read Gedcomx document from
+   * @return Gedcomx document
+   * @throws JAXBException
+   */
+  public static Gedcomx unmarshal(InputStream inputStream) throws JAXBException {
+    return (Gedcomx)createUnmarshaller().unmarshal(inputStream);
+  }
+
+  /**
+   * Convert a GedcomX document to XML (with newlines and indentation)
+   * @param doc - GedcomX document to convert
+   * @return XML string representing the GedcomX document
+   */
+  public static String toXml(Gedcomx doc) {
+    try {
+      StringWriter sw = new StringWriter();
+      getMarshaller(true).marshal(doc, sw);
+      return sw.toString();
+    } catch (JAXBException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  /**
+   * Convert a GedcomX RecordSet to XML (with newlines and indentation)
+   * @param recordSet - GedcomX RecordSet to convert
+   * @return XML string representing the GedcomX RecordSet
+   */
+  public static String toXml(RecordSet recordSet) {
+    try {
+      StringWriter sw = new StringWriter();
+      getMarshaller(true).marshal(recordSet, sw);
+      return sw.toString();
+    } catch (JAXBException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+}

--- a/gedcomx-model/src/test/java/org/gedcomx/util/TestFieldMap.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/util/TestFieldMap.java
@@ -1,0 +1,45 @@
+package org.gedcomx.util;
+
+import junit.framework.TestCase;
+import org.gedcomx.Gedcomx;
+
+import javax.xml.bind.JAXBException;
+import java.util.Locale;
+
+/**
+ * Class for...
+ * User: Randy Wilson
+ * Date: 7/31/2014
+ * Time: 12:04 PM
+ */
+public class TestFieldMap extends TestCase {
+
+  public void testRecordFieldMap() throws JAXBException {
+    Gedcomx record = MarshalUtil.unmarshal(getClass().getClassLoader().getResourceAsStream("gedcomx-record.xml"));
+    Gedcomx collection = MarshalUtil.unmarshal(getClass().getClassLoader().getResourceAsStream("gedcomx-collection.xml"));
+    FieldMap fieldMap = new FieldMap(record, collection);
+    assertEquals("Maria Johanna Potgieter Van Wyk", fieldMap.getValues("PR_NAME").get(0));
+    assertEquals("Name", fieldMap.getDisplayLabel("PR_NAME", "en"));
+    assertEquals("Nombre", fieldMap.getDisplayLabel("PR_NAME", "es"));
+    assertNull(fieldMap.getDisplayLabel("BATCH_LOCALITY", "en"));
+    assertEquals("South Africa", fieldMap.getValues("BATCH_LOCALITY").get(0));
+    assertNull(fieldMap.getValues("IMAGE_TYPE")); // empty
+    assertNull(fieldMap.getValues("NOT_A_REAL_LABEL_ID")); // doesn't exist
+  }
+
+  /**
+   * Test an 'image item', which is a small record with no persons or relationships, but only a few "fields" that are
+   *   used to tag a group of images to support image browsing.
+   * @throws JAXBException
+   */
+  public void testImageItemFieldMap() throws JAXBException {
+    Gedcomx imageItem = MarshalUtil.unmarshal(getClass().getClassLoader().getResourceAsStream("gedcomx-image.xml"));
+    Gedcomx collection = MarshalUtil.unmarshal(getClass().getClassLoader().getResourceAsStream("gedcomx-collection.xml"));
+    FieldMap fieldMap = new FieldMap(imageItem, collection);
+    assertEquals("1962", fieldMap.getValues("YEAR").get(0));
+    assertEquals("1116", fieldMap.getValues("FILE_NUMBER").get(0));
+    assertEquals("Year", fieldMap.getDisplayLabel("YEAR", Locale.ENGLISH.toLanguageTag()));
+    assertEquals("Año", fieldMap.getDisplayLabel("YEAR", "es"));
+    assertEquals("년도", fieldMap.getDisplayLabel("YEAR", "ko"));
+  }
+}

--- a/gedcomx-model/src/test/java/org/gedcomx/util/TestLocaleUtil.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/util/TestLocaleUtil.java
@@ -1,0 +1,57 @@
+package org.gedcomx.util;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.gedcomx.common.TextValue;
+
+import java.util.*;
+
+/**
+ * Class for...
+ * User: Randy Wilson
+ * Date: 7/31/2014
+ * Time: 12:03 PM
+ */
+public class TestLocaleUtil extends TestCase {
+
+  public void testTextValueLocales() {
+    List<TextValue> list = Arrays.asList(
+            value("Spanish", "es"),
+            value("UK English", "en-GB"),
+            value("US English", "en-US"),
+            value("Korean", "ko"));
+    assertEquals("Spanish", LocaleUtil.findClosestLocale(list, Locale.forLanguageTag("es")).getValue());
+    assertEquals("UK English", LocaleUtil.findClosestLocale(list, Locale.forLanguageTag("en-GB")).getValue());
+    assertEquals("UK English", LocaleUtil.findClosestLocale(list, Locale.forLanguageTag("en")).getValue()); // first English in list
+    assertEquals("US English", LocaleUtil.findClosestLocale(list, Locale.forLanguageTag("en-US")).getValue()); // first English in list
+    assertEquals("Korean", LocaleUtil.findClosestLocale(list, Locale.KOREAN).getValue()); //ko
+    assertEquals("Korean", LocaleUtil.findClosestLocale(list, Locale.KOREA).getValue()); //ko-KR
+    // Test a case where there is no good match to the preferred language, but there is to the default language.
+    assertEquals("UK English", LocaleUtil.findClosestLocale(list, Locale.JAPANESE, Locale.CANADA).getValue());
+    assertEquals("US English", LocaleUtil.findClosestLocale(list, Locale.JAPANESE, Locale.US).getValue());
+  }
+
+  private static TextValue value(String text, String lang) {
+    TextValue v = new TextValue(text);
+    v.setLang(lang);
+    return v;
+  }
+
+  public void testLocales() {
+    Set<Locale> list = new LinkedHashSet<Locale>(Arrays.asList(
+            Locale.forLanguageTag("es"),
+            Locale.forLanguageTag("en-GB"),
+            Locale.forLanguageTag("en-US"),
+            Locale.forLanguageTag("ko")));
+    assertEquals("es", LocaleUtil.findClosestLocale(list, Locale.forLanguageTag("es")).toLanguageTag());
+    assertEquals("en-GB", LocaleUtil.findClosestLocale(list, Locale.forLanguageTag("en-GB")).toLanguageTag());
+    assertEquals("en-GB", LocaleUtil.findClosestLocale(list, Locale.forLanguageTag("en")).toLanguageTag()); // first English in list
+    assertEquals("ko", LocaleUtil.findClosestLocale(list, Locale.KOREAN).toLanguageTag()); //ko
+    assertEquals("ko", LocaleUtil.findClosestLocale(list, Locale.KOREA).toLanguageTag()); //ko-KR
+    // Test a case where there is no good match to the preferred language, but there is to the default language.
+    assertEquals("en-GB", LocaleUtil.findClosestLocale(list, Locale.JAPANESE, Locale.CANADA).toLanguageTag());
+    assertEquals("en-US", LocaleUtil.findClosestLocale(list, Locale.JAPANESE, Locale.US).toLanguageTag());
+  }
+
+}

--- a/gedcomx-model/src/test/java/org/gedcomx/util/TestRecordSetIterator.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/util/TestRecordSetIterator.java
@@ -1,0 +1,39 @@
+package org.gedcomx.util;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.gedcomx.Gedcomx;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+/**
+ * Class for testing the RecordIterator
+ * User: Randy Wilson
+ * Date: 11/21/13
+ * Time: 1:46 PM
+ */
+public class TestRecordSetIterator extends TestCase {
+
+  public void testParser() throws IOException, XMLStreamException {
+    InputStream inputStream = getClass().getClassLoader().getResourceAsStream("gedcomx-recordset.xml");
+    Iterator<Gedcomx> recordIterator = new RecordSetIterator(inputStream);
+    assertTrue(recordIterator.hasNext());
+    Gedcomx record1 = recordIterator.next();
+    Gedcomx record2 = recordIterator.next();
+    Gedcomx record3 = recordIterator.next();
+    assertEquals("r_14946444", record1.getId());
+    assertEquals("r_21837581269", record2.getId());
+    assertEquals("r_731503667", record3.getId());
+    assertNotNull(record1);
+    assertNotNull(record2);
+    assertNotNull(record3);
+    assertEquals(6, record3.getPersons().size());
+    assertFalse(recordIterator.hasNext());
+    assertNull(recordIterator.next());
+    assertNull(recordIterator.next());
+  }
+}

--- a/gedcomx-model/src/test/java/org/gedcomx/util/TestRecordSetWriter.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/util/TestRecordSetWriter.java
@@ -1,0 +1,52 @@
+package org.gedcomx.util;
+
+import junit.framework.TestCase;
+import org.gedcomx.Gedcomx;
+
+import javax.xml.bind.JAXBException;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Class for testing the RecordSetWriter and RecordSetIterator class.
+ * User: Randy Wilson
+ * Date: 12/4/13
+ * Time: 3:39 PM
+ */
+public class TestRecordSetWriter extends TestCase {
+
+  public void testRecordSetWriter() throws IOException, JAXBException {
+    for (boolean isGzipped : new boolean[]{false, true}) {
+      InputStream inputStream = getClass().getClassLoader().getResourceAsStream("gedcomx-recordset.xml");
+      int numRecords = 0;
+      RecordSetIterator recordIterator = new RecordSetIterator(inputStream, false);
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      OutputStream outputStream = isGzipped ? new GZIPOutputStream(bos) : bos;
+      RecordSetWriter writer = new RecordSetWriter(outputStream);
+      Gedcomx record;
+      List<String> recordIds = new ArrayList<String>();
+      List<Gedcomx> records = new ArrayList<Gedcomx>();
+
+      String[] expectedRecordIds = new String[]{"r_14946444", "r_21837581269", "r_731503667"};
+      while ((record = recordIterator.next()) != null) {
+        assertEquals(expectedRecordIds[numRecords++], record.getId());
+        writer.writeRecord(record);
+        records.add(record);
+        recordIds.add(record.getId());
+      }
+      writer.close();
+      assertEquals(3, records.size());
+
+      byte[] bytes = bos.toByteArray();
+      recordIterator = new RecordSetIterator(new ByteArrayInputStream(bytes), isGzipped);
+      for (int i = 0; i < numRecords; i++) {
+        record = recordIterator.next();
+        assertNotNull(record);
+        assertEquals(recordIds.get(i), record.getId());
+      }
+      assertNull(recordIterator.next());
+    }
+  }
+}

--- a/gedcomx-model/src/test/resources/gedcomx-collection.xml
+++ b/gedcomx-model/src/test/resources/gedcomx-collection.xml
@@ -1,0 +1,359 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<gedcomx xmlns="http://gedcomx.org/v1/" xmlns:fs="http://familysearch.org/v1/" xmlns:atom="http://www.w3.org/2005/Atom" description="#src_1">
+    <sourceDescription about="https://familysearch.org/platform/records/collections/1407787" resourceType="http://gedcomx.org/Collection" id="src_1">
+        <citation>
+            <value>"South Africa, Orange Free State, Estate Files, 1951-2006." Index and images. &lt;i&gt;FamilySearch&lt;/i&gt;. http://FamilySearch.org : accessed 2014. Citing The Master of Supreme Court. Master of the Free State High Court, Bloemfontein.</value>
+        </citation>
+        <componentOf description="#src_2"/>
+        <title>South Africa, Orange Free State, Estate Files, 1951-2006</title>
+        <description xml:lang="en_US">Images of estate files from The Master of Supreme Court in Bloemfontein. This collection (including text, images, databases and other information) is owned or licensed by GSU. You may view, download, and print material from this collection only for your personal, noncommercial use unless we specifically indicate that other uses are permitted. You may not use this site or information found at this site (including the names and addresses of those who submit information) for selling or promoting products or services, soliciting clients, or any other commercial purpose. Notwithstanding the foregoing, we reserve the right, at our sole discretion, to deny, revoke, or limit use of this site to any person. GSU is not responsible for any use that you make of materials from this site, and you agree to fully indemnify GSU for any claims against GSU based on your actions. In many instances, we do not provide source citations, and in no case do we guarantee that materials on this site may be used for anything beyond personal, noncommercial genealogical research.</description>
+        <identifier type="http://gedcomx.org/Primary">https://familysearch.org/platform/records/collections/1407787</identifier>
+        <coverage>
+            <recordType>http://gedcomx.org/Probate</recordType>
+            <spatial description="#place_1927115">
+                <original>South Africa</original>
+            </spatial>
+            <temporal>
+                <original>1951/2006</original>
+                <formal>+1951/+2006</formal>
+            </temporal>
+        </coverage>
+        <rights/>
+    </sourceDescription>
+    <sourceDescription about="https://familysearch.org/platform/records/collections" resourceType="http://familysearch.org/types/resources/Container" id="src_2">
+        <identifier type="http://gedcomx.org/Primary">https://familysearch.org/platform/records/collections</identifier>
+    </sourceDescription>
+    <place>
+        <identifier type="http://gedcomx.org/Primary">https://api.familysearch.org/authorities/v1/place/1927115</identifier>
+        <name>South Africa</name>
+    </place>
+    <collection xml:lang="en_US">
+        <title>South Africa, Orange Free State, Estate Files, 1951-2006</title>
+        <size>3911204</size>
+        <content>
+            <completeness>1.0</completeness>
+            <count>19126</count>
+            <resourceType>http://gedcomx.org/Record</resourceType>
+        </content>
+        <content>
+            <completeness>1.0</completeness>
+            <count>66716</count>
+            <resourceType>http://gedcomx.org/Person</resourceType>
+        </content>
+        <content>
+            <completeness>1.0</completeness>
+            <count>3892078</count>
+            <resourceType>http://gedcomx.org/DigitalArtifact</resourceType>
+        </content>
+    </collection>
+    <recordDescriptor id="rd_MM9.1.9/MMMM-MLG">
+        <field>
+            <value labelId="PR_NAME">
+                <label xml:lang="de">Name</label>
+                <label xml:lang="it">Nome</label>
+                <label xml:lang="ru">Имя</label>
+                <label xml:lang="es">Nombre</label>
+                <label xml:lang="fr">Nom</label>
+                <label xml:lang="ja">名前</label>
+                <label xml:lang="zh">姓名</label>
+                <label xml:lang="pt">Nome</label>
+                <label xml:lang="en_us">Name</label>
+                <label xml:lang="default">Name</label>
+                <label xml:lang="ko">성과 이름</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="EVENT_TYPE">
+                <label xml:lang="en_us">Event Type</label>
+                <label xml:lang="it">Tipologia di evento</label>
+                <label xml:lang="ja">イベントの種類</label>
+                <label xml:lang="ru">Тип события</label>
+                <label xml:lang="ko">사건 발생 유형</label>
+                <label xml:lang="zh">事項類型</label>
+                <label xml:lang="pt">Tipo de evento</label>
+                <label xml:lang="fr">Type d'événement</label>
+                <label xml:lang="es">Tipo de evento</label>
+                <label xml:lang="default">Event Type</label>
+                <label xml:lang="de">Ereignistyp</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="EVENT_DATE">
+                <label xml:lang="en_us">Event Date</label>
+                <label xml:lang="ja">イベント日付</label>
+                <label xml:lang="fr">Date de l'événement</label>
+                <label xml:lang="ko">사건 발생 날짜</label>
+                <label xml:lang="ru">Дата события</label>
+                <label xml:lang="default">Event Date</label>
+                <label xml:lang="es">Fecha del evento</label>
+                <label xml:lang="de">Ereignisdatum</label>
+                <label xml:lang="pt">Data do evento</label>
+                <label xml:lang="zh">事項日期</label>
+                <label xml:lang="it">Data dell'evento</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="EVENT_PLACE">
+                <label xml:lang="en_us">Event Place</label>
+                <label xml:lang="pt">Local do evento</label>
+                <label xml:lang="ko">사건 발생 장소</label>
+                <label xml:lang="default">Event Place</label>
+                <label xml:lang="it">Luogo dell'evento</label>
+                <label xml:lang="de">Ereignisort</label>
+                <label xml:lang="es">Lugar del evento</label>
+                <label xml:lang="ru">Место мероприятия</label>
+                <label xml:lang="fr">Lieu de l'événement</label>
+                <label xml:lang="ja">イベント場所</label>
+                <label xml:lang="zh">事項地點</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="PR_AGE">
+                <label xml:lang="en_us">Age</label>
+                <label xml:lang="zh">年齡</label>
+                <label xml:lang="es">Edad</label>
+                <label xml:lang="pt">Idade</label>
+                <label xml:lang="de">Alter</label>
+                <label xml:lang="ja">年令</label>
+                <label xml:lang="default">Age</label>
+                <label xml:lang="fr">Âge</label>
+                <label xml:lang="ru">Возраст</label>
+                <label xml:lang="it">Età</label>
+                <label xml:lang="ko">나이</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="PR_BIRTH_YEAR_ESTIMATED">
+                <label xml:lang="en_us">Birth Year (Estimated)</label>
+                <label xml:lang="es">Año de nacimiento (aproximado)</label>
+                <label xml:lang="it">Anno di nascita (approssimativo)</label>
+                <label xml:lang="de">Geburtsjahr (geschätzt)</label>
+                <label xml:lang="ru">Год рождения (примерный)</label>
+                <label xml:lang="ko">출생 년도 (예상)</label>
+                <label xml:lang="default">Birth Year (Estimated)</label>
+                <label xml:lang="ja">出生年（推定）</label>
+                <label xml:lang="zh">出生年份（估計）</label>
+                <label xml:lang="fr">Année de naissance (estimée)</label>
+                <label xml:lang="pt">Ano de nascimento (estimado)</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="PR_BIRTH_PLACE">
+                <label xml:lang="en_us">Birthplace</label>
+                <label xml:lang="zh">出生地</label>
+                <label xml:lang="pt">Local de nascimento</label>
+                <label xml:lang="it">Luogo di nascita</label>
+                <label xml:lang="es">Lugar de nacimiento</label>
+                <label xml:lang="default">Birthplace</label>
+                <label xml:lang="ru">Место рождения</label>
+                <label xml:lang="fr">Lieu de naissance</label>
+                <label xml:lang="ko">출생지</label>
+                <label xml:lang="de">Geburtsort</label>
+                <label xml:lang="ja">出生地</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="PR_FTHR_NAME">
+                <label xml:lang="en_us">Father's Name</label>
+                <label xml:lang="it">Nome del padre</label>
+                <label xml:lang="default">Father's Name</label>
+                <label xml:lang="ko">아버지의 이름</label>
+                <label xml:lang="pt">Nome do pai</label>
+                <label xml:lang="zh">父親名字</label>
+                <label xml:lang="ja">父親の名前</label>
+                <label xml:lang="fr">Nom du père</label>
+                <label xml:lang="ru">Имя отца</label>
+                <label xml:lang="es">Nombre del padre</label>
+                <label xml:lang="de">Name des Vaters</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="PR_MTHR_NAME">
+                <label xml:lang="en_us">Mother's Name</label>
+                <label xml:lang="zh">母親名字</label>
+                <label xml:lang="pt">Nome da mãe</label>
+                <label xml:lang="default">Mother's Name</label>
+                <label xml:lang="it">Nome della madre</label>
+                <label xml:lang="ko">어머니의 성과 이름</label>
+                <label xml:lang="de">Name der Mutter</label>
+                <label xml:lang="ru">Имя матери</label>
+                <label xml:lang="es">Nombre de la madre</label>
+                <label xml:lang="fr">Nom de la mère</label>
+                <label xml:lang="ja">母親の名前</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="SPOUSE_NAME">
+                <label xml:lang="en_us">Spouse's Name</label>
+                <label xml:lang="es">Nombre del cónyuge</label>
+                <label xml:lang="ja">配偶者の名前</label>
+                <label xml:lang="pt">Nome do cônjuge</label>
+                <label xml:lang="ru">Имя супруга</label>
+                <label xml:lang="fr">Nom du conjoint</label>
+                <label xml:lang="zh">配偶名字</label>
+                <label xml:lang="default">Spouse's Name</label>
+                <label xml:lang="it">Nome del coniuge</label>
+                <label xml:lang="ko">배우자의 이름</label>
+                <label xml:lang="de">Name des Ehepartners</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="SPOUSE_2_NAME">
+                <label xml:lang="en_us">Additional Spouse's Name</label>
+                <label xml:lang="it">Nome del secondo coniuge</label>
+                <label xml:lang="ja">配偶者の名前の追加</label>
+                <label xml:lang="default">Additional Spouse's Name</label>
+                <label xml:lang="es">Nombre del cónyuge adicional</label>
+                <label xml:lang="de">Name des anderen Ehepartners</label>
+                <label xml:lang="pt">Nome do cônjuge (suplemento)</label>
+                <label xml:lang="ru">Имена других супругов</label>
+                <label xml:lang="zh">其他配偶姓名</label>
+                <label xml:lang="fr">Nom de l'autre conjoint</label>
+                <label xml:lang="ko">재혼 배우자의 이름</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="OTHER_NAMES">
+                <label xml:lang="en_us">Other Name(s)</label>
+                <label xml:lang="ko">다른 이름 (들)</label>
+                <label xml:lang="default">Other Name(s)</label>
+                <label xml:lang="pt">Outro(s) Nome(s)</label>
+                <label xml:lang="zh">其他名字</label>
+                <label xml:lang="de">Weitere Namen</label>
+                <label xml:lang="it">Ulteriore Nome (o nomi)</label>
+                <label xml:lang="ru">Другие имена</label>
+                <label xml:lang="es">Otros nombres</label>
+                <label xml:lang="fr">Autre nom (s)</label>
+                <label xml:lang="ja">他の名前（複数可）</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="DIGITAL_GS_NUMBER">
+                <label xml:lang="en_us">Digital Folder Number</label>
+                <label xml:lang="it">Numero della cartella digitale</label>
+                <label xml:lang="de">Digitale Ordnernummer</label>
+                <label xml:lang="es">Número de carpeta digital</label>
+                <label xml:lang="ru">Цифровой номер папки</label>
+                <label xml:lang="fr">Numéro de dossier numérique</label>
+                <label xml:lang="ja">デジタルフォルダー番号</label>
+                <label xml:lang="default">Digital Folder Number</label>
+                <label xml:lang="ko">디지털 서류철 번호</label>
+                <label xml:lang="pt">Número da pasta digital</label>
+                <label xml:lang="zh">數位檔案夾編號</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="IMAGE_NBR">
+                <label xml:lang="en_us">Image Number</label>
+                <label xml:lang="pt">Número da imagem</label>
+                <label xml:lang="ja">画像番号</label>
+                <label xml:lang="es">Número de imagen</label>
+                <label xml:lang="fr">Numéro de l'image</label>
+                <label xml:lang="ko">이미지 번호</label>
+                <label xml:lang="default">Image Number</label>
+                <label xml:lang="ru">Номер изображения</label>
+                <label xml:lang="de">Aufnahmenummer</label>
+                <label xml:lang="it">Numero immagine</label>
+                <label xml:lang="zh">影像編號</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="BATCH_LOCALITY"/>
+        </field>
+        <field>
+            <value labelId="EXCLUDE_FROM_EXPORT"/>
+        </field>
+        <field>
+            <value labelId="FOLDER_IMAGE_SEQ"/>
+        </field>
+        <field>
+            <value labelId="FOLDER"/>
+        </field>
+        <field>
+            <value labelId="FS_COLLECTION_ID"/>
+        </field>
+        <field>
+            <value labelId="IMAGE_ID"/>
+        </field>
+        <field>
+            <value labelId="IMAGE_APID"/>
+        </field>
+        <field>
+            <value labelId="IMAGE_PAL"/>
+        </field>
+        <field>
+            <value labelId="IMAGE_TYPE"/>
+        </field>
+        <field>
+            <value labelId="LANGUAGE"/>
+        </field>
+        <field>
+            <value labelId="PPQ_ID"/>
+        </field>
+        <field>
+            <value labelId="PR_FTHR_NAME_GN"/>
+        </field>
+        <field>
+            <value labelId="PR_FTHR_NAME_SURN"/>
+        </field>
+        <field>
+            <value labelId="PR_MTHR_NAME_GN"/>
+        </field>
+        <field>
+            <value labelId="PR_MTHR_NAME_SURN"/>
+        </field>
+        <field>
+            <value labelId="PR_NAME_GN"/>
+        </field>
+        <field>
+            <value labelId="PR_NAME_SURN"/>
+        </field>
+        <field>
+            <value labelId="RECORD_GROUP"/>
+        </field>
+        <field>
+            <value labelId="SORT_KEY"/>
+        </field>
+        <field>
+            <value labelId="SPOUSE_2_NAME_GN"/>
+        </field>
+        <field>
+            <value labelId="SPOUSE_2_NAME_SURN"/>
+        </field>
+        <field>
+            <value labelId="SPOUSE_3_NAME"/>
+        </field>
+        <field>
+            <value labelId="SPOUSE_3_NAME_GN"/>
+        </field>
+        <field>
+            <value labelId="SPOUSE_3_NAME_SURN"/>
+        </field>
+        <field>
+            <value labelId="SPOUSE_NAME_GN"/>
+        </field>
+        <field>
+            <value labelId="SPOUSE_NAME_SURN"/>
+        </field>
+        <field>
+            <value labelId="TRAVELER_NAME"/>
+        </field>
+        <field>
+            <value labelId="UNIQUE_IDENTIFIER"/>
+        </field>
+    </recordDescriptor>
+    <recordDescriptor id="wd_1407787">
+        <field>
+            <value labelId="YEAR" type="http://gedcomx.org/Original">
+                <label xml:lang="en">Year</label>
+                <label xml:lang="es">Año</label>
+                <label xml:lang="ko">년도</label>
+            </value>
+        </field>
+        <field>
+            <value labelId="FILE_NUMBER" type="http://gedcomx.org/Original">
+                <label xml:lang="en">File Number</label>
+            </value>
+        </field>
+    </recordDescriptor>
+</gedcomx>

--- a/gedcomx-model/src/test/resources/gedcomx-image.xml
+++ b/gedcomx-model/src/test/resources/gedcomx-image.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gedcomx xmlns="http://gedcomx.org/v1/" description="#s1">
+  <sourceDescription about="https://familysearch.org/platform/records/imageItems/3WP4-978?cc=1133" resourceType="http://gedcomx.org/Record" id="s1">
+    <source description="#s2"/>
+    <componentOf description="#s3"/>
+    <identifier type="http://gedcomx.org/Primary">https://familysearch.org/platform/records/imageItems/3WP4-978?cc=1133</identifier>
+    <descriptor resource="https://familysearch.org/platform/records/collections/1407787#wd_1407787"/>
+  </sourceDescription>
+  <sourceDescription about="https://familysearch.org/ark:/61903/3:1:S3HT-DRB9-V94" resourceType="http://gedcomx.org/DigitalArtifact" id="s2">
+    <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/ark:/61903/3:1:S3HT-DRB9-V94</identifier>
+  </sourceDescription>
+  <sourceDescription about="https://familysearch.org/platform/records/collections/1407787" resourceType="http://gedcomx.org/Collection" id="s3">
+    <identifier type="http://gedcomx.org/Primary">https://familysearch.org/platform/records/collections/1407787</identifier>
+  </sourceDescription>
+  <field type="http://familysearch.org/types/fields/YEAR">
+    <value labelId="YEAR" type="http://gedcomx.org/Original">
+      <text>1962</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/FILE_NUMBER">
+    <value labelId="FILE_NUMBER" type="http://gedcomx.org/Original">
+      <text>1116</text>
+    </value>
+  </field>
+</gedcomx>

--- a/gedcomx-model/src/test/resources/gedcomx-record.xml
+++ b/gedcomx-model/src/test/resources/gedcomx-record.xml
@@ -1,0 +1,308 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gedcomx xmlns="http://gedcomx.org/v1/" description="#src_r_1453055601" id="r_1453055601">
+  <person principal="true" extracted="true" id="p_11156434701">
+    <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/ark:/61903/1:1:FC38-HNL</identifier>
+    <name type="http://gedcomx.org/BirthName">
+      <nameForm>
+        <fullText>Maria Johanna Potgieter Van Wyk</fullText>
+        <part type="http://gedcomx.org/Given" value="Maria Johanna">
+          <field type="http://gedcomx.org/Given">
+            <value labelId="PR_NAME_GN" type="http://gedcomx.org/Interpreted">
+              <text>Maria Johanna</text>
+            </value>
+          </field>
+        </part>
+        <part type="http://gedcomx.org/Surname" value="Potgieter Van Wyk">
+          <field type="http://gedcomx.org/Surname">
+            <value labelId="PR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+              <text>Potgieter Van Wyk</text>
+            </value>
+          </field>
+        </part>
+        <field type="http://gedcomx.org/Name">
+          <value labelId="PR_NAME" type="http://gedcomx.org/Interpreted">
+            <text>Maria Johanna Potgieter Van Wyk</text>
+          </value>
+        </field>
+      </nameForm>
+    </name>
+    <fact primary="true" type="http://gedcomx.org/Death">
+      <date>
+        <original>17 Feb 1960</original>
+        <field type="http://gedcomx.org/Date">
+          <value labelId="EVENT_DATE" type="http://gedcomx.org/Interpreted">
+            <text>17 Feb 1960</text>
+          </value>
+        </field>
+      </date>
+      <place>
+        <original>Harrismith</original>
+        <field type="http://gedcomx.org/Place">
+          <value labelId="EVENT_PLACE" type="http://gedcomx.org/Interpreted">
+            <text>Harrismith</text>
+          </value>
+        </field>
+      </place>
+    </fact>
+    <fact type="http://gedcomx.org/Birth">
+      <date>
+        <original>1878</original>
+        <field type="http://gedcomx.org/Year">
+          <value labelId="PR_BIRTH_YEAR_ESTIMATED" type="http://gedcomx.org/Interpreted">
+            <text>1878</text>
+          </value>
+        </field>
+      </date>
+      <place>
+        <original>Humansdorp</original>
+        <field type="http://gedcomx.org/Place">
+          <value labelId="PR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+            <text>Humansdorp</text>
+          </value>
+        </field>
+      </place>
+    </fact>
+    <field type="http://gedcomx.org/Age">
+      <value labelId="PR_AGE" type="http://gedcomx.org/Interpreted">
+        <text>82</text>
+      </value>
+    </field>
+  </person>
+  <person extracted="true" id="p_11156434702">
+    <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/ark:/61903/1:1:FC38-HNG</identifier>
+    <gender type="http://gedcomx.org/Male">
+      <field type="http://gedcomx.org/Gender">
+        <value resource="http://gedcomx.org/Male" type="http://gedcomx.org/Original">
+          <text>Male</text>
+        </value>
+      </field>
+    </gender>
+    <name type="http://gedcomx.org/BirthName">
+      <nameForm>
+        <fullText>Matthys Josephus Potgieter</fullText>
+        <part type="http://gedcomx.org/Given" value="Matthys Josephus">
+          <field type="http://gedcomx.org/Given">
+            <value labelId="PR_FTHR_NAME_GN" type="http://gedcomx.org/Interpreted">
+              <text>Matthys Josephus</text>
+            </value>
+          </field>
+        </part>
+        <part type="http://gedcomx.org/Surname" value="Potgieter">
+          <field type="http://gedcomx.org/Surname">
+            <value labelId="PR_FTHR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+              <text>Potgieter</text>
+            </value>
+          </field>
+        </part>
+        <field type="http://gedcomx.org/Name">
+          <value labelId="PR_FTHR_NAME" type="http://gedcomx.org/Interpreted">
+            <text>Matthys Josephus Potgieter</text>
+          </value>
+        </field>
+      </nameForm>
+    </name>
+  </person>
+  <person extracted="true" id="p_11156434703">
+    <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/ark:/61903/1:1:FC38-HNP</identifier>
+    <gender type="http://gedcomx.org/Female">
+      <field type="http://gedcomx.org/Gender">
+        <value resource="http://gedcomx.org/Female" type="http://gedcomx.org/Original">
+          <text>Female</text>
+        </value>
+      </field>
+    </gender>
+    <name type="http://gedcomx.org/BirthName">
+      <nameForm>
+        <fullText>Gertruida Woutrina Potgieter</fullText>
+        <part type="http://gedcomx.org/Given" value="Gertruida Woutrina">
+          <field type="http://gedcomx.org/Given">
+            <value labelId="PR_MTHR_NAME_GN" type="http://gedcomx.org/Interpreted">
+              <text>Gertruida Woutrina</text>
+            </value>
+          </field>
+        </part>
+        <part type="http://gedcomx.org/Surname" value="Potgieter">
+          <field type="http://gedcomx.org/Surname">
+            <value labelId="PR_MTHR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+              <text>Potgieter</text>
+            </value>
+          </field>
+        </part>
+        <field type="http://gedcomx.org/Name">
+          <value labelId="PR_MTHR_NAME" type="http://gedcomx.org/Interpreted">
+            <text>Gertruida Woutrina Potgieter</text>
+          </value>
+        </field>
+      </nameForm>
+    </name>
+  </person>
+  <person extracted="true" id="p_11156434704">
+    <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/ark:/61903/1:1:FC38-HN5</identifier>
+    <name type="http://gedcomx.org/BirthName">
+      <nameForm>
+        <fullText>Pieter Abraham Albertus Van Wyk</fullText>
+        <part type="http://gedcomx.org/Given" value="Pieter Abraham Albertus">
+          <field type="http://gedcomx.org/Given">
+            <value labelId="SPOUSE_NAME_GN" type="http://gedcomx.org/Interpreted">
+              <text>Pieter Abraham Albertus</text>
+            </value>
+          </field>
+        </part>
+        <part type="http://gedcomx.org/Surname" value="Van Wyk">
+          <field type="http://gedcomx.org/Surname">
+            <value labelId="SPOUSE_NAME_SURN" type="http://gedcomx.org/Interpreted">
+              <text>Van Wyk</text>
+            </value>
+          </field>
+        </part>
+        <field type="http://gedcomx.org/Name">
+          <value labelId="SPOUSE_NAME" type="http://gedcomx.org/Interpreted">
+            <text>Pieter Abraham Albertus Van Wyk</text>
+          </value>
+        </field>
+      </nameForm>
+    </name>
+  </person>
+  <relationship type="http://gedcomx.org/Couple" id="MM9.1.6/78TF-8JF">
+    <person1 resource="#p_11156434701"/>
+    <person2 resource="#p_11156434704"/>
+  </relationship>
+  <relationship type="http://gedcomx.org/ParentChild" id="MM9.1.6/78TF-8JN">
+    <person1 resource="#p_11156434702"/>
+    <person2 resource="#p_11156434701"/>
+  </relationship>
+  <relationship type="http://gedcomx.org/ParentChild" id="MM9.1.6/78TF-8JJ">
+    <person1 resource="#p_11156434703"/>
+    <person2 resource="#p_11156434701"/>
+  </relationship>
+  <relationship type="http://gedcomx.org/Couple" id="MM9.1.6/78TF-8JV">
+    <person1 resource="#p_11156434702"/>
+    <person2 resource="#p_11156434703"/>
+  </relationship>
+  <sourceDescription about="https://familysearch.org/ark:/61903/1:2:91PT-TWL" resourceType="http://gedcomx.org/Record" id="src_r_1453055601">
+    <citation>
+      <value>"South Africa, Orange Free State, Estate Files, 1951-2006," index and images, &lt;i>FamilySearch&lt;/i> (https://familysearch.org/ark:/61903/1:1:FC38-HNL : accessed 22 Jul 2014), Maria Johanna Potgieter Van Wyk, 17 Feb 1960, Death; citing Harrismith, Master of the Free State High Court, Bloemfontein; FHL microfilm 004229835.</value>
+    </citation>
+    <source description="#src_s1"/>
+    <componentOf description="#src_2"/>
+    <title xml:lang="en-US">Entry for Maria Johanna Potgieter Van Wyk, "South Africa, Orange Free State, Estate Files, 1951-2006"</title>
+    <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/ark:/61903/1:2:91PT-TWL</identifier>
+    <identifier>https://familysearch.org/platform/externalId/easy/1000605267248</identifier>
+    <created>2014-02-19T20:16:40.712Z</created>
+    <modified>2014-05-24T12:50:54.647Z</modified>
+    <coverage>
+      <recordType>http://gedcomx.org/Probate</recordType>
+      <spatial>
+        <original>South Africa</original>
+      </spatial>
+      <temporal>
+        <original>17 Feb 1960</original>
+      </temporal>
+    </coverage>
+    <descriptor resource="https://familysearch.org/platform/records/collections/1407787#rd_MM9.1.9/MMMM-MLG"/>
+  </sourceDescription>
+  <sourceDescription about="https://familysearch.org/platform/records/collections/1407787" resourceType="http://gedcomx.org/Collection" id="src_1">
+    <title xml:lang="en-US">South Africa, Orange Free State, Estate Files, 1951-2006</title>
+    <identifier type="http://gedcomx.org/Primary">https://familysearch.org/platform/records/collections/1407787</identifier>
+    <coverage>
+      <recordType>http://gedcomx.org/Probate</recordType>
+      <spatial description="#place_1927115">
+        <original>South Africa</original>
+      </spatial>
+    </coverage>
+  </sourceDescription>
+  <sourceDescription about="https://familysearch.org/platform/records/collections/1407787/records" resourceType="http://familysearch.org/types/resources/Container" id="src_2">
+    <componentOf description="#src_1"/>
+    <title xml:lang="en-US">South Africa, Orange Free State, Estate Files, 1951-2006</title>
+    <identifier type="http://gedcomx.org/Primary">https://familysearch.org/platform/records/collections/1407787/records</identifier>
+  </sourceDescription>
+  <sourceDescription about="https://familysearch.org/ark:/61903/3:1:S3HY-DKTS-PZ1?cc=1133" resourceType="http://gedcomx.org/DigitalArtifact" id="src_s1">
+    <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/ark:/61903/3:1:S3HY-DKTS-PZ1?cc=1133</identifier>
+  </sourceDescription>
+  <place id="place_1927115">
+    <identifier type="http://gedcomx.org/Primary">https://api.familysearch.org/authorities/v1/place/1927115</identifier>
+  </place>
+  <field type="http://familysearch.org/types/fields/UniqueIdentifier">
+    <value labelId="UNIQUE_IDENTIFIER" type="http://gedcomx.org/Original">
+      <text>1000605267248</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/ImageId">
+    <value labelId="IMAGE_ID" type="http://gedcomx.org/Original">
+      <text>/004229835/004229835_00280.jpg</text>
+    </value>
+    <value labelId="IMAGE_ID_NORM" type="http://gedcomx.org/Interpreted">
+      <text>dgs:004229835.004229835_00280</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/FolderImageSeq">
+    <value labelId="FOLDER_IMAGE_SEQ" type="http://gedcomx.org/Original">
+      <text>280</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/Folder">
+    <value labelId="FOLDER" type="http://gedcomx.org/Original">
+      <text>004229835</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/BatchLocality">
+    <value labelId="BATCH_LOCALITY" type="http://gedcomx.org/Original">
+      <text>South Africa</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/DigitalGsNumber">
+    <value labelId="DIGITAL_GS_NUMBER" type="http://gedcomx.org/Original">
+      <text>004229835</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/EventType">
+    <value labelId="EVENT_TYPE" type="http://gedcomx.org/Original">
+      <text>Death</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/FsCollectionId">
+    <value labelId="FS_COLLECTION_ID" type="http://gedcomx.org/Original">
+      <text>1407787</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/ImageApid">
+    <value labelId="IMAGE_APID" type="http://gedcomx.org/Original">
+      <text>TH-267-11396-75029-65</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/ImageNbr">
+    <value labelId="IMAGE_NBR" type="http://gedcomx.org/Original">
+      <text>00280</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/ImageArk">
+    <value labelId="IMAGE_ARK" type="http://gedcomx.org/Original">
+      <text>https://familysearch.org/ark:/61903/3:1:S3HY-DKTS-PZ1</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/Language">
+    <value labelId="LANGUAGE" type="http://gedcomx.org/Original">
+      <text>Afrikaans</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/OtherNames">
+    <value labelId="OTHER_NAMES" type="http://gedcomx.org/Original">
+      <text>CHILD_1:Matthys Josephus Van Wyk; CHILD_2:Petronella Maria Van Wyk Kriel</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/PpqId">
+    <value labelId="PPQ_ID" type="http://gedcomx.org/Original">
+      <text>10-0203</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/RecordGroup">
+    <value labelId="RECORD_GROUP" type="http://gedcomx.org/Original">
+      <text>10-0203; 27-OCT-2011 15:50:13.179365; Default</text>
+    </value>
+  </field>
+  <field type="http://familysearch.org/types/fields/Sortkey">
+    <value labelId="SORT_KEY" type="http://gedcomx.org/Original">
+      <text>collection:00000000000000001133,easyId:1000605267248</text>
+    </value>
+  </field>
+</gedcomx>

--- a/gedcomx-model/src/test/resources/gedcomx-recordset.xml
+++ b/gedcomx-model/src/test/resources/gedcomx-recordset.xml
@@ -1,0 +1,3099 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<records xmlns="http://gedcomx.org/v1/">
+  <record description="#s1" xml:lang="en-US" id="r_14946444">
+    <person principal="true" id="p_1">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/XZL3-8FP</identifier>
+      <gender type="http://gedcomx.org/Male">
+        <field type="http://gedcomx.org/Gender">
+          <value labelId="SEX_CODE_ORIG" type="http://gedcomx.org/Original">
+            <text>M</text>
+          </value>
+          <value labelId="SEX_CODE_STD" type="http://gedcomx.org/Interpreted">
+            <text>Male</text>
+          </value>
+        </field>
+      </gender>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Thomas T. Holdaway</fullText>
+          <part type="http://gedcomx.org/Given" value="Thomas T.">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="PR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Thomas T.</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Holdaway">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="PR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Holdaway</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="PR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Thomas T. Holdaway</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+      <fact primary="true" type="http://gedcomx.org/Death">
+        <date>
+          <original>25 Sep 1945</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="DEATH_DATE_ORIG" type="http://gedcomx.org/Original">
+              <text>25 Sept 1945</text>
+            </value>
+            <value labelId="DEATH_DATE_STD" type="http://gedcomx.org/Interpreted">
+              <text>25 Sep 1945</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>Salt Lake City, Salt Lake, Utah</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="DEATH_PLACE" type="http://gedcomx.org/Original">
+              <text>Salt Lake City, Salt Lake, Utah</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact type="http://gedcomx.org/MaritalStatus">
+        <value>Married</value>
+        <field type="http://gedcomx.org/MaritalStatus">
+          <value labelId="MARITAL_STATUS" type="http://gedcomx.org/Interpreted">
+            <text>Married</text>
+          </value>
+        </field>
+      </fact>
+    </person>
+    <person id="p_2">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/XZL3-8F5</identifier>
+      <gender type="http://gedcomx.org/Male"/>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>David Oscar Holdaway</fullText>
+          <part type="http://gedcomx.org/Given" value="David Oscar">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="FTHR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>David Oscar</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Holdaway">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="FTHR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Holdaway</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="FTHR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>David Oscar Holdaway</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+    </person>
+    <person id="p_3">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/XZL3-8FR</identifier>
+      <gender type="http://gedcomx.org/Female"/>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Elizabeth Amanda Prates</fullText>
+          <part type="http://gedcomx.org/Given" value="Elizabeth Amanda">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="MTHR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Elizabeth Amanda</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Prates">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="MTHR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Prates</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="MTHR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Elizabeth Amanda Prates</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+    </person>
+    <person id="p_4">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/XZL3-8FT</identifier>
+      <gender type="http://gedcomx.org/Female"/>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Mary Eliza White</fullText>
+          <part type="http://gedcomx.org/Given" value="Mary Eliza">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="SPOUSE_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Mary Eliza</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="White">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="SPOUSE_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>White</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="SPOUSE_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Mary Eliza White</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+    </person>
+    <relationship type="http://gedcomx.org/Couple">
+      <person1 resource="#p_1"/>
+      <person2 resource="#p_4"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_2"/>
+      <person2 resource="#p_1"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_3"/>
+      <person2 resource="#p_1"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/Couple">
+      <person1 resource="#p_2"/>
+      <person2 resource="#p_3"/>
+    </relationship>
+    <sourceDescription about="https://familysearch.org/pal:/MM9.1.2/MMV6-JQ5" resourceType="http://gedcomx.org/Record" id="s1">
+      <citation>
+        <value>"Utah Death Certificates, 1904-1956," index and images, &lt;i&gt;FamilySearch&lt;/i&gt;
+          (https://familysearch.org/pal:/MM9.1.2/MMV6-JQ5 : accessed 16 Apr 2013), Thomas T. Holdaway, 25 Sep 1945.
+        </value>
+      </citation>
+      <source description="#s2"/>
+      <componentOf description="#s3"/>
+      <title xml:lang="en-US">Entry for Thomas T. Holdaway, "Utah Death Certificates, 1904-1956"</title>
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.2/MMV6-JQ5</identifier>
+      <identifier>http://familysearch.org/externalId/easy/record_id/194324786</identifier>
+      <created>2010-03-17T18:00:00-06:00</created>
+      <modified>2011-08-23T18:00:00-06:00</modified>
+      <coverage>
+        <recordType>http://gedcomx.org/Death</recordType>
+        <spatial>
+          <original>Salt Lake City, Salt Lake, Utah</original>
+        </spatial>
+        <temporal>
+          <original>25 Sep 1945</original>
+        </temporal>
+      </coverage>
+      <descriptor resource="https://familysearch.org/records/collections/1747615#rd_1747615"/>
+    </sourceDescription>
+    <sourceDescription about="https://familysearch.org/records/collection/1747615/records" resourceType="http://familysearch.org/types/facts/Container" id="s3">
+      <componentOf description="#s4"/>
+      <title xml:lang="en-US">Utah Death Certificates, 1904-1956</title>
+      <identifier type="http://gedcomx.org/Primary">https://familysearch.org/records/collection/1747615/records</identifier>
+    </sourceDescription>
+    <sourceDescription about="https://familysearch.org/records/collection/1747615" resourceType="http://gedcomx.org/Collection" id="s4">
+      <title xml:lang="en-US">Utah Death Certificates, 1904-1956</title>
+      <identifier type="http://gedcomx.org/Primary">https://familysearch.org/records/collection/1747615</identifier>
+    </sourceDescription>
+    <sourceDescription about="https://familysearch.org/pal:/MM9.3.1/TH-267-11047-191970-91?cc=1747615" resourceType="http://gedcomx.org/DigitalArtifact" id="s2">
+      <attribution>
+        <contributor resource="#a1"/>
+      </attribution>
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.3.1/TH-267-11047-191970-91?cc=1747615</identifier>
+    </sourceDescription>
+    <agent id="a1">
+      <name>familysearch.org</name>
+    </agent>
+    <field type="http://familysearch.org/types/fields/AGE_IN_YEARS">
+      <value labelId="AGE_IN_YEARS" type="http://gedcomx.org/Original">
+        <text>88</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/BATCH_LOCALITY">
+      <value labelId="BATCH_LOCALITY" type="http://gedcomx.org/Original">
+        <text>Utah, United States</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/DEATH_AGE_FORMATTED">
+      <value labelId="DEATH_AGE_FORMATTED" type="http://gedcomx.org/Original">
+        <text>88 years 1 month 6 days</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/DEATH_AGE_ORIG">
+      <value labelId="DEATH_AGE_ORIG" type="http://gedcomx.org/Original">
+        <text>88y 1m 6d</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/DEATH_PLACE_ORIG">
+      <value labelId="DEATH_PLACE_ORIG" type="http://gedcomx.org/Original">
+        <text>Salt Lake City, Salt Lake, Utah</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/DEATH_YEAR">
+      <value labelId="DEATH_YEAR" type="http://gedcomx.org/Original">
+        <text>1945</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/DIGITAL_GS_NUMBER">
+      <value labelId="DIGITAL_GS_NUMBER" type="http://gedcomx.org/Original">
+        <text>4120942</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/ESTIMATED_BIRTH_YEAR">
+      <value labelId="ESTIMATED_BIRTH_YEAR" type="http://gedcomx.org/Original">
+        <text>1857</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/FOLDER_IMAGE_SEQ">
+      <value labelId="FOLDER_IMAGE_SEQ" type="http://gedcomx.org/Original">
+        <text>1448</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/GSU_FILM_NUMBER">
+      <value labelId="GSU_FILM_NUMBER" type="http://gedcomx.org/Original">
+        <text>2260786</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/IMAGE_ID">
+      <value labelId="IMAGE_ID" type="http://gedcomx.org/Original">
+        <text>dgs:002260786.002260786_01448</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/IMAGE_NBR">
+      <value labelId="IMAGE_NBR" type="http://gedcomx.org/Original">
+        <text>1448</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/REF_ID">
+      <value labelId="REF_ID" type="http://gedcomx.org/Original">
+        <text>1537</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/UNIQUE_IDENTIFIER">
+      <value labelId="UNIQUE_IDENTIFIER" type="http://gedcomx.org/Original">
+        <text>194324786</text>
+      </value>
+    </field>
+  </record>
+  <record description="#s5" xml:lang="en-US" id="r_21837581269">
+    <person principal="true" id="p_5">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/MMRT-YS7</identifier>
+      <identifier>http://familysearch.org/externalId/easy/record_id/464785022</identifier>
+      <gender type="http://gedcomx.org/Male">
+        <field type="http://gedcomx.org/Gender">
+          <value labelId="PR_SEX_CODE_ORIG" type="http://gedcomx.org/Original">
+            <text>M</text>
+          </value>
+          <value labelId="PR_SEX_CODE" type="http://gedcomx.org/Interpreted">
+            <text>Male</text>
+          </value>
+        </field>
+      </gender>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Thomas Holdaway</fullText>
+          <part type="http://gedcomx.org/Given" value="Thomas">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="PR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Thomas</text>
+              </value>
+              <value labelId="PR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Thomas</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Holdaway">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="PR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Holdaway</text>
+              </value>
+              <value labelId="PR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Holdaway</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="PR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Thomas/Holdaway</text>
+            </value>
+            <value labelId="PR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Thomas Holdaway</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+      <fact type="http://gedcomx.org/Birth">
+        <date>
+          <original>Aug 1857</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="PR_BIRTH_DATE_ORIG" type="http://gedcomx.org/Original">
+              <text>Aug 1857</text>
+            </value>
+            <value labelId="PR_BIRTH_DATE" type="http://gedcomx.org/Interpreted">
+              <text>Aug 1857</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Year">
+            <value labelId="PR_BIRTH_YEAR_ORIG" type="http://gedcomx.org/Original">
+              <text>1857</text>
+            </value>
+            <value labelId="PR_BIRTH_YEAR" type="http://gedcomx.org/Interpreted">
+              <text>1857</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Month">
+            <value labelId="PR_BIRTH_MONTH" type="http://gedcomx.org/Interpreted">
+              <text>Aug</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>Utah</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="PR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact primary="true" type="http://gedcomx.org/Census">
+        <date>
+          <original>1900</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="EVENT_DATE" type="http://gedcomx.org/Interpreted">
+              <text>1900</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="EVENT_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_4" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_3" type="http://gedcomx.org/Interpreted">
+              <text>Uintah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_2" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_1" type="http://gedcomx.org/Interpreted">
+              <text>United States</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact type="http://gedcomx.org/MaritalStatus">
+        <value>Married</value>
+        <field type="http://gedcomx.org/MaritalStatus">
+          <value labelId="PR_MARITAL_STATUS_ORIG" type="http://gedcomx.org/Original">
+            <text>M</text>
+          </value>
+          <value labelId="PR_MARITAL_STATUS" type="http://gedcomx.org/Interpreted">
+            <text>Married</text>
+          </value>
+        </field>
+      </fact>
+      <field type="http://familysearch.org/types/fields/BATCH_ID">
+        <value labelId="BATCH_ID" type="http://gedcomx.org/Original">
+          <text>461419</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/BATCH_LOCALITY">
+        <value labelId="BATCH_LOCALITY" type="http://gedcomx.org/Original">
+          <text>Utah, United States</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/COLLECTION_ID">
+        <value labelId="COLLECTION_ID" type="http://gedcomx.org/Original">
+          <text>1325221</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/DIGITAL_GS_NUMBER">
+        <value labelId="DIGITAL_GS_NUMBER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_1_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_1_TYPE" type="http://gedcomx.org/Original">
+          <text>Country</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_2_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_2_TYPE" type="http://gedcomx.org/Original">
+          <text>State</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_3_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_3_TYPE" type="http://gedcomx.org/Original">
+          <text>County</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_4_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_4_TYPE" type="http://gedcomx.org/Original">
+          <text>Town</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_TYPE">
+        <value labelId="EVENT_TYPE" type="http://gedcomx.org/Original">
+          <text>Census</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FILM_NUMBER">
+        <value labelId="FILM_NUMBER" type="http://gedcomx.org/Original">
+          <text>1241687</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER">
+        <value labelId="FOLDER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER_IMAGE_SEQ">
+        <value labelId="FOLDER_IMAGE_SEQ" type="http://gedcomx.org/Original">
+          <text>782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/HOUSEHOLD_ID">
+        <value labelId="HOUSEHOLD_ID" type="http://gedcomx.org/Original">
+          <text>73</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_APID">
+        <value labelId="IMAGE_APID" type="http://gedcomx.org/Original">
+          <text>TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_ID">
+        <value labelId="IMAGE_ID" type="http://gedcomx.org/Original">
+          <text>/004115262/004115262_00782.jpg</text>
+        </value>
+        <value labelId="IMAGE_ID_NORM" type="http://gedcomx.org/Interpreted">
+          <text>dgs:004115262.004115262_00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_NBR">
+        <value labelId="IMAGE_NBR" type="http://gedcomx.org/Original">
+          <text>00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_PAL">
+        <value labelId="IMAGE_PAL" type="http://gedcomx.org/Original">
+          <text>https://familysearch.org/pal:/MM9.3.1/TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PACKET_LTR">
+        <value labelId="PACKET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PAGE">
+        <value labelId="PAGE" type="http://gedcomx.org/Original">
+          <text>4</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PPQ_ID">
+        <value labelId="PPQ_ID" type="http://gedcomx.org/Original">
+          <text>12-0679</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_ETHNICITY_CSS">
+        <value labelId="PR_ETHNICITY_CSS" type="http://gedcomx.org/Original">
+          <text>American</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_MARRIAGE_YEAR_ESTIMATED">
+        <value labelId="PR_MARRIAGE_YEAR_ESTIMATED" type="http://gedcomx.org/Original">
+          <text>1877</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RACE_OR_COLOR_CSS">
+        <value labelId="PR_RACE_OR_COLOR_CSS" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RELATIONSHIP_TO_HEAD_CSS">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_CSS" type="http://gedcomx.org/Original">
+          <text>Head</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_GROUP">
+        <value labelId="RECORD_GROUP" type="http://gedcomx.org/Original">
+          <text>; 11-APR-2012 15:47:12.242092; Default</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_ID">
+        <value labelId="RECORD_ID" type="http://gedcomx.org/Original">
+          <text>004115262_00782_22</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REC_NBR">
+        <value labelId="REC_NBR" type="http://gedcomx.org/Original">
+          <text>37746</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REF_ID">
+        <value labelId="REF_ID" type="http://gedcomx.org/Original">
+          <text>23</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RELATIONSHIP_CODE">
+        <value labelId="RELATIONSHIP_CODE" type="http://gedcomx.org/Original">
+          <text>HEAD</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SHEET_LTR">
+        <value labelId="SHEET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SORT_KEY">
+        <value labelId="SORT_KEY" type="http://gedcomx.org/Original">
+          <text>000000000_004115262_00782_022_000464785022</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SPOUSE_BIRTH_PLACE">
+        <value labelId="SPOUSE_BIRTH_PLACE" type="http://gedcomx.org/Original">
+          <text>Utah</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UDE_BATCH_NUMBER">
+        <value labelId="UDE_BATCH_NUMBER" type="http://gedcomx.org/Original">
+          <text>N00675-2</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UNIQUE_IDENTIFIER">
+        <value labelId="UNIQUE_IDENTIFIER" type="http://gedcomx.org/Original">
+          <text>464785022</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/YEARS_MARRIED">
+        <value labelId="YEARS_MARRIED" type="http://gedcomx.org/Original">
+          <text>23</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/YEARS_MARRIED_ORIG">
+        <value labelId="YEARS_MARRIED_ORIG" type="http://gedcomx.org/Original">
+          <text>23</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Age">
+        <value labelId="PR_AGE_ORIG" type="http://gedcomx.org/Original">
+          <text>43y</text>
+        </value>
+        <value labelId="PR_AGE" type="http://gedcomx.org/Interpreted">
+          <text>43</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Race">
+        <value labelId="PR_RACE_OR_COLOR_ORIG" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+        <value labelId="PR_RACE_OR_COLOR" type="http://gedcomx.org/Interpreted">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/RelationshipToHead">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_ORIG" type="http://gedcomx.org/Original">
+          <text>Head</text>
+        </value>
+        <value labelId="PR_RELATIONSHIP_TO_HEAD" type="http://gedcomx.org/Interpreted">
+          <text>Head</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/FatherBirthPlace">
+        <value labelId="PR_FTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Tennessee</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/MotherBirthPlace">
+        <value labelId="PR_MTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Iowa</text>
+        </value>
+      </field>
+    </person>
+    <person principal="true" id="p_6">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/MMRT-YSW</identifier>
+      <identifier>http://familysearch.org/externalId/easy/record_id/464785023</identifier>
+      <gender type="http://gedcomx.org/Female">
+        <field type="http://gedcomx.org/Gender">
+          <value labelId="PR_SEX_CODE_ORIG" type="http://gedcomx.org/Original">
+            <text>F</text>
+          </value>
+          <value labelId="PR_SEX_CODE" type="http://gedcomx.org/Interpreted">
+            <text>Female</text>
+          </value>
+        </field>
+      </gender>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Mary E Holdaway</fullText>
+          <part type="http://gedcomx.org/Given" value="Mary E">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="PR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Mary E</text>
+              </value>
+              <value labelId="PR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Mary E</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Holdaway">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="PR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Holdaway</text>
+              </value>
+              <value labelId="PR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Holdaway</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="PR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Mary E/Holdaway</text>
+            </value>
+            <value labelId="PR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Mary E Holdaway</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+      <fact type="http://gedcomx.org/Birth">
+        <date>
+          <original>Mar 1861</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="PR_BIRTH_DATE_ORIG" type="http://gedcomx.org/Original">
+              <text>Mar 1861</text>
+            </value>
+            <value labelId="PR_BIRTH_DATE" type="http://gedcomx.org/Interpreted">
+              <text>Mar 1861</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Year">
+            <value labelId="PR_BIRTH_YEAR_ORIG" type="http://gedcomx.org/Original">
+              <text>1861</text>
+            </value>
+            <value labelId="PR_BIRTH_YEAR" type="http://gedcomx.org/Interpreted">
+              <text>1861</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Month">
+            <value labelId="PR_BIRTH_MONTH" type="http://gedcomx.org/Interpreted">
+              <text>Mar</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>Utah</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="PR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact primary="true" type="http://gedcomx.org/Census">
+        <date>
+          <original>1900</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="EVENT_DATE" type="http://gedcomx.org/Interpreted">
+              <text>1900</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="EVENT_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_4" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_3" type="http://gedcomx.org/Interpreted">
+              <text>Uintah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_2" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_1" type="http://gedcomx.org/Interpreted">
+              <text>United States</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact type="http://gedcomx.org/MaritalStatus">
+        <value>Married</value>
+        <field type="http://gedcomx.org/MaritalStatus">
+          <value labelId="PR_MARITAL_STATUS_ORIG" type="http://gedcomx.org/Original">
+            <text>M</text>
+          </value>
+          <value labelId="PR_MARITAL_STATUS" type="http://gedcomx.org/Interpreted">
+            <text>Married</text>
+          </value>
+        </field>
+      </fact>
+      <field type="http://familysearch.org/types/fields/BATCH_ID">
+        <value labelId="BATCH_ID" type="http://gedcomx.org/Original">
+          <text>461419</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/BATCH_LOCALITY">
+        <value labelId="BATCH_LOCALITY" type="http://gedcomx.org/Original">
+          <text>Utah, United States</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/COLLECTION_ID">
+        <value labelId="COLLECTION_ID" type="http://gedcomx.org/Original">
+          <text>1325221</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/DIGITAL_GS_NUMBER">
+        <value labelId="DIGITAL_GS_NUMBER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_1_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_1_TYPE" type="http://gedcomx.org/Original">
+          <text>Country</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_2_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_2_TYPE" type="http://gedcomx.org/Original">
+          <text>State</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_3_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_3_TYPE" type="http://gedcomx.org/Original">
+          <text>County</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_4_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_4_TYPE" type="http://gedcomx.org/Original">
+          <text>Town</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_TYPE">
+        <value labelId="EVENT_TYPE" type="http://gedcomx.org/Original">
+          <text>Census</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FILM_NUMBER">
+        <value labelId="FILM_NUMBER" type="http://gedcomx.org/Original">
+          <text>1241687</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER">
+        <value labelId="FOLDER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER_IMAGE_SEQ">
+        <value labelId="FOLDER_IMAGE_SEQ" type="http://gedcomx.org/Original">
+          <text>782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/HOUSEHOLD_ID">
+        <value labelId="HOUSEHOLD_ID" type="http://gedcomx.org/Original">
+          <text>73</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_APID">
+        <value labelId="IMAGE_APID" type="http://gedcomx.org/Original">
+          <text>TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_ID">
+        <value labelId="IMAGE_ID" type="http://gedcomx.org/Original">
+          <text>/004115262/004115262_00782.jpg</text>
+        </value>
+        <value labelId="IMAGE_ID_NORM" type="http://gedcomx.org/Interpreted">
+          <text>dgs:004115262.004115262_00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_NBR">
+        <value labelId="IMAGE_NBR" type="http://gedcomx.org/Original">
+          <text>00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_PAL">
+        <value labelId="IMAGE_PAL" type="http://gedcomx.org/Original">
+          <text>https://familysearch.org/pal:/MM9.3.1/TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PACKET_LTR">
+        <value labelId="PACKET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PAGE">
+        <value labelId="PAGE" type="http://gedcomx.org/Original">
+          <text>4</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PPQ_ID">
+        <value labelId="PPQ_ID" type="http://gedcomx.org/Original">
+          <text>12-0679</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_ETHNICITY_CSS">
+        <value labelId="PR_ETHNICITY_CSS" type="http://gedcomx.org/Original">
+          <text>American</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_MARRIAGE_YEAR_ESTIMATED">
+        <value labelId="PR_MARRIAGE_YEAR_ESTIMATED" type="http://gedcomx.org/Original">
+          <text>1877</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_MTHR_HOW_MANY_CHILDREN">
+        <value labelId="PR_MTHR_HOW_MANY_CHILDREN" type="http://gedcomx.org/Original">
+          <text>5</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_NUMBER_LIVING_CHILDREN">
+        <value labelId="PR_NUMBER_LIVING_CHILDREN" type="http://gedcomx.org/Original">
+          <text>5</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RACE_OR_COLOR_CSS">
+        <value labelId="PR_RACE_OR_COLOR_CSS" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RELATIONSHIP_TO_HEAD_CSS">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_CSS" type="http://gedcomx.org/Original">
+          <text>Wife</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_GROUP">
+        <value labelId="RECORD_GROUP" type="http://gedcomx.org/Original">
+          <text>; 11-APR-2012 15:47:12.242092; Default</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_ID">
+        <value labelId="RECORD_ID" type="http://gedcomx.org/Original">
+          <text>004115262_00782_23</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REC_NBR">
+        <value labelId="REC_NBR" type="http://gedcomx.org/Original">
+          <text>37747</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REF_ID">
+        <value labelId="REF_ID" type="http://gedcomx.org/Original">
+          <text>24</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RELATIONSHIP_CODE">
+        <value labelId="RELATIONSHIP_CODE" type="http://gedcomx.org/Original">
+          <text>WIFE</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SHEET_LTR">
+        <value labelId="SHEET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SORT_KEY">
+        <value labelId="SORT_KEY" type="http://gedcomx.org/Original">
+          <text>000000000_004115262_00782_023_000464785023</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SPOUSE_BIRTH_PLACE">
+        <value labelId="SPOUSE_BIRTH_PLACE" type="http://gedcomx.org/Original">
+          <text>Utah</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UDE_BATCH_NUMBER">
+        <value labelId="UDE_BATCH_NUMBER" type="http://gedcomx.org/Original">
+          <text>N00675-2</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UNIQUE_IDENTIFIER">
+        <value labelId="UNIQUE_IDENTIFIER" type="http://gedcomx.org/Original">
+          <text>464785023</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/YEARS_MARRIED">
+        <value labelId="YEARS_MARRIED" type="http://gedcomx.org/Original">
+          <text>23</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/YEARS_MARRIED_ORIG">
+        <value labelId="YEARS_MARRIED_ORIG" type="http://gedcomx.org/Original">
+          <text>23</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Age">
+        <value labelId="PR_AGE_ORIG" type="http://gedcomx.org/Original">
+          <text>39y</text>
+        </value>
+        <value labelId="PR_AGE" type="http://gedcomx.org/Interpreted">
+          <text>39</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Race">
+        <value labelId="PR_RACE_OR_COLOR_ORIG" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+        <value labelId="PR_RACE_OR_COLOR" type="http://gedcomx.org/Interpreted">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/RelationshipToHead">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_ORIG" type="http://gedcomx.org/Original">
+          <text>Wife</text>
+        </value>
+        <value labelId="PR_RELATIONSHIP_TO_HEAD" type="http://gedcomx.org/Interpreted">
+          <text>Wife</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/FatherBirthPlace">
+        <value labelId="PR_FTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>England</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/MotherBirthPlace">
+        <value labelId="PR_MTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>England</text>
+        </value>
+      </field>
+    </person>
+    <person principal="true" id="p_7">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/MMRT-YS4</identifier>
+      <identifier>http://familysearch.org/externalId/easy/record_id/464785024</identifier>
+      <gender type="http://gedcomx.org/Male">
+        <field type="http://gedcomx.org/Gender">
+          <value labelId="PR_SEX_CODE_ORIG" type="http://gedcomx.org/Original">
+            <text>M</text>
+          </value>
+          <value labelId="PR_SEX_CODE" type="http://gedcomx.org/Interpreted">
+            <text>Male</text>
+          </value>
+        </field>
+      </gender>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Henry H Holdaway</fullText>
+          <part type="http://gedcomx.org/Given" value="Henry H">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="PR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Henry H</text>
+              </value>
+              <value labelId="PR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Henry H</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Holdaway">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="PR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Holdaway</text>
+              </value>
+              <value labelId="PR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Holdaway</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="PR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Henry H/Holdaway</text>
+            </value>
+            <value labelId="PR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Henry H Holdaway</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+      <fact type="http://gedcomx.org/Birth">
+        <date>
+          <original>May 1884</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="PR_BIRTH_DATE_ORIG" type="http://gedcomx.org/Original">
+              <text>May 1884</text>
+            </value>
+            <value labelId="PR_BIRTH_DATE" type="http://gedcomx.org/Interpreted">
+              <text>May 1884</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Year">
+            <value labelId="PR_BIRTH_YEAR_ORIG" type="http://gedcomx.org/Original">
+              <text>1884</text>
+            </value>
+            <value labelId="PR_BIRTH_YEAR" type="http://gedcomx.org/Interpreted">
+              <text>1884</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Month">
+            <value labelId="PR_BIRTH_MONTH" type="http://gedcomx.org/Interpreted">
+              <text>May</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>Utah</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="PR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact primary="true" type="http://gedcomx.org/Census">
+        <date>
+          <original>1900</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="EVENT_DATE" type="http://gedcomx.org/Interpreted">
+              <text>1900</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="EVENT_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_4" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_3" type="http://gedcomx.org/Interpreted">
+              <text>Uintah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_2" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_1" type="http://gedcomx.org/Interpreted">
+              <text>United States</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact type="http://gedcomx.org/MaritalStatus">
+        <value>Single</value>
+        <field type="http://gedcomx.org/MaritalStatus">
+          <value labelId="PR_MARITAL_STATUS_ORIG" type="http://gedcomx.org/Original">
+            <text>S</text>
+          </value>
+          <value labelId="PR_MARITAL_STATUS" type="http://gedcomx.org/Interpreted">
+            <text>Single</text>
+          </value>
+        </field>
+      </fact>
+      <field type="http://familysearch.org/types/fields/BATCH_ID">
+        <value labelId="BATCH_ID" type="http://gedcomx.org/Original">
+          <text>461419</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/BATCH_LOCALITY">
+        <value labelId="BATCH_LOCALITY" type="http://gedcomx.org/Original">
+          <text>Utah, United States</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/COLLECTION_ID">
+        <value labelId="COLLECTION_ID" type="http://gedcomx.org/Original">
+          <text>1325221</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/DIGITAL_GS_NUMBER">
+        <value labelId="DIGITAL_GS_NUMBER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_1_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_1_TYPE" type="http://gedcomx.org/Original">
+          <text>Country</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_2_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_2_TYPE" type="http://gedcomx.org/Original">
+          <text>State</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_3_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_3_TYPE" type="http://gedcomx.org/Original">
+          <text>County</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_4_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_4_TYPE" type="http://gedcomx.org/Original">
+          <text>Town</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_TYPE">
+        <value labelId="EVENT_TYPE" type="http://gedcomx.org/Original">
+          <text>Census</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FILM_NUMBER">
+        <value labelId="FILM_NUMBER" type="http://gedcomx.org/Original">
+          <text>1241687</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER">
+        <value labelId="FOLDER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER_IMAGE_SEQ">
+        <value labelId="FOLDER_IMAGE_SEQ" type="http://gedcomx.org/Original">
+          <text>782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/HOUSEHOLD_ID">
+        <value labelId="HOUSEHOLD_ID" type="http://gedcomx.org/Original">
+          <text>73</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_APID">
+        <value labelId="IMAGE_APID" type="http://gedcomx.org/Original">
+          <text>TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_ID">
+        <value labelId="IMAGE_ID" type="http://gedcomx.org/Original">
+          <text>/004115262/004115262_00782.jpg</text>
+        </value>
+        <value labelId="IMAGE_ID_NORM" type="http://gedcomx.org/Interpreted">
+          <text>dgs:004115262.004115262_00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_NBR">
+        <value labelId="IMAGE_NBR" type="http://gedcomx.org/Original">
+          <text>00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_PAL">
+        <value labelId="IMAGE_PAL" type="http://gedcomx.org/Original">
+          <text>https://familysearch.org/pal:/MM9.3.1/TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PACKET_LTR">
+        <value labelId="PACKET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PAGE">
+        <value labelId="PAGE" type="http://gedcomx.org/Original">
+          <text>4</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PPQ_ID">
+        <value labelId="PPQ_ID" type="http://gedcomx.org/Original">
+          <text>12-0679</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_ETHNICITY_CSS">
+        <value labelId="PR_ETHNICITY_CSS" type="http://gedcomx.org/Original">
+          <text>American</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RACE_OR_COLOR_CSS">
+        <value labelId="PR_RACE_OR_COLOR_CSS" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RELATIONSHIP_TO_HEAD_CSS">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_CSS" type="http://gedcomx.org/Original">
+          <text>Son</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_GROUP">
+        <value labelId="RECORD_GROUP" type="http://gedcomx.org/Original">
+          <text>; 11-APR-2012 15:47:12.242092; Default</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_ID">
+        <value labelId="RECORD_ID" type="http://gedcomx.org/Original">
+          <text>004115262_00782_24</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REC_NBR">
+        <value labelId="REC_NBR" type="http://gedcomx.org/Original">
+          <text>37748</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REF_ID">
+        <value labelId="REF_ID" type="http://gedcomx.org/Original">
+          <text>25</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RELATIONSHIP_CODE">
+        <value labelId="RELATIONSHIP_CODE" type="http://gedcomx.org/Original">
+          <text>SON</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SHEET_LTR">
+        <value labelId="SHEET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SORT_KEY">
+        <value labelId="SORT_KEY" type="http://gedcomx.org/Original">
+          <text>000000000_004115262_00782_024_000464785024</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UDE_BATCH_NUMBER">
+        <value labelId="UDE_BATCH_NUMBER" type="http://gedcomx.org/Original">
+          <text>N00675-2</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UNIQUE_IDENTIFIER">
+        <value labelId="UNIQUE_IDENTIFIER" type="http://gedcomx.org/Original">
+          <text>464785024</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Age">
+        <value labelId="PR_AGE_ORIG" type="http://gedcomx.org/Original">
+          <text>16y</text>
+        </value>
+        <value labelId="PR_AGE" type="http://gedcomx.org/Interpreted">
+          <text>16</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Race">
+        <value labelId="PR_RACE_OR_COLOR_ORIG" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+        <value labelId="PR_RACE_OR_COLOR" type="http://gedcomx.org/Interpreted">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/RelationshipToHead">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_ORIG" type="http://gedcomx.org/Original">
+          <text>Son</text>
+        </value>
+        <value labelId="PR_RELATIONSHIP_TO_HEAD" type="http://gedcomx.org/Interpreted">
+          <text>Son</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/FatherBirthPlace">
+        <value labelId="PR_FTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Utah</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/MotherBirthPlace">
+        <value labelId="PR_MTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Utah</text>
+        </value>
+      </field>
+    </person>
+    <person principal="true" id="p_8">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/MMRT-YSH</identifier>
+      <identifier>http://familysearch.org/externalId/easy/record_id/464785025</identifier>
+      <gender type="http://gedcomx.org/Female">
+        <field type="http://gedcomx.org/Gender">
+          <value labelId="PR_SEX_CODE_ORIG" type="http://gedcomx.org/Original">
+            <text>F</text>
+          </value>
+          <value labelId="PR_SEX_CODE" type="http://gedcomx.org/Interpreted">
+            <text>Female</text>
+          </value>
+        </field>
+      </gender>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Flosa W Holdaway</fullText>
+          <part type="http://gedcomx.org/Given" value="Flosa W">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="PR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Flosa W</text>
+              </value>
+              <value labelId="PR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Flosa W</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Holdaway">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="PR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Holdaway</text>
+              </value>
+              <value labelId="PR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Holdaway</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="PR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Flosa W/Holdaway</text>
+            </value>
+            <value labelId="PR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Flosa W Holdaway</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+      <fact type="http://gedcomx.org/Birth">
+        <date>
+          <original>Apr 1890</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="PR_BIRTH_DATE_ORIG" type="http://gedcomx.org/Original">
+              <text>Apr 1890</text>
+            </value>
+            <value labelId="PR_BIRTH_DATE" type="http://gedcomx.org/Interpreted">
+              <text>Apr 1890</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Year">
+            <value labelId="PR_BIRTH_YEAR_ORIG" type="http://gedcomx.org/Original">
+              <text>1890</text>
+            </value>
+            <value labelId="PR_BIRTH_YEAR" type="http://gedcomx.org/Interpreted">
+              <text>1890</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Month">
+            <value labelId="PR_BIRTH_MONTH" type="http://gedcomx.org/Interpreted">
+              <text>Apr</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>Utah</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="PR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact primary="true" type="http://gedcomx.org/Census">
+        <date>
+          <original>1900</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="EVENT_DATE" type="http://gedcomx.org/Interpreted">
+              <text>1900</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="EVENT_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_4" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_3" type="http://gedcomx.org/Interpreted">
+              <text>Uintah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_2" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_1" type="http://gedcomx.org/Interpreted">
+              <text>United States</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact type="http://gedcomx.org/MaritalStatus">
+        <value>Single</value>
+        <field type="http://gedcomx.org/MaritalStatus">
+          <value labelId="PR_MARITAL_STATUS_ORIG" type="http://gedcomx.org/Original">
+            <text>S</text>
+          </value>
+          <value labelId="PR_MARITAL_STATUS" type="http://gedcomx.org/Interpreted">
+            <text>Single</text>
+          </value>
+        </field>
+      </fact>
+      <field type="http://familysearch.org/types/fields/BATCH_ID">
+        <value labelId="BATCH_ID" type="http://gedcomx.org/Original">
+          <text>461419</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/BATCH_LOCALITY">
+        <value labelId="BATCH_LOCALITY" type="http://gedcomx.org/Original">
+          <text>Utah, United States</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/COLLECTION_ID">
+        <value labelId="COLLECTION_ID" type="http://gedcomx.org/Original">
+          <text>1325221</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/DIGITAL_GS_NUMBER">
+        <value labelId="DIGITAL_GS_NUMBER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_1_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_1_TYPE" type="http://gedcomx.org/Original">
+          <text>Country</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_2_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_2_TYPE" type="http://gedcomx.org/Original">
+          <text>State</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_3_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_3_TYPE" type="http://gedcomx.org/Original">
+          <text>County</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_4_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_4_TYPE" type="http://gedcomx.org/Original">
+          <text>Town</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_TYPE">
+        <value labelId="EVENT_TYPE" type="http://gedcomx.org/Original">
+          <text>Census</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FILM_NUMBER">
+        <value labelId="FILM_NUMBER" type="http://gedcomx.org/Original">
+          <text>1241687</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER">
+        <value labelId="FOLDER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER_IMAGE_SEQ">
+        <value labelId="FOLDER_IMAGE_SEQ" type="http://gedcomx.org/Original">
+          <text>782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/HOUSEHOLD_ID">
+        <value labelId="HOUSEHOLD_ID" type="http://gedcomx.org/Original">
+          <text>73</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_APID">
+        <value labelId="IMAGE_APID" type="http://gedcomx.org/Original">
+          <text>TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_ID">
+        <value labelId="IMAGE_ID" type="http://gedcomx.org/Original">
+          <text>/004115262/004115262_00782.jpg</text>
+        </value>
+        <value labelId="IMAGE_ID_NORM" type="http://gedcomx.org/Interpreted">
+          <text>dgs:004115262.004115262_00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_NBR">
+        <value labelId="IMAGE_NBR" type="http://gedcomx.org/Original">
+          <text>00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_PAL">
+        <value labelId="IMAGE_PAL" type="http://gedcomx.org/Original">
+          <text>https://familysearch.org/pal:/MM9.3.1/TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PACKET_LTR">
+        <value labelId="PACKET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PAGE">
+        <value labelId="PAGE" type="http://gedcomx.org/Original">
+          <text>4</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PPQ_ID">
+        <value labelId="PPQ_ID" type="http://gedcomx.org/Original">
+          <text>12-0679</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_ETHNICITY_CSS">
+        <value labelId="PR_ETHNICITY_CSS" type="http://gedcomx.org/Original">
+          <text>American</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RACE_OR_COLOR_CSS">
+        <value labelId="PR_RACE_OR_COLOR_CSS" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RELATIONSHIP_TO_HEAD_CSS">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_CSS" type="http://gedcomx.org/Original">
+          <text>Daughter</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_GROUP">
+        <value labelId="RECORD_GROUP" type="http://gedcomx.org/Original">
+          <text>; 11-APR-2012 15:47:12.242092; Default</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_ID">
+        <value labelId="RECORD_ID" type="http://gedcomx.org/Original">
+          <text>004115262_00782_25</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REC_NBR">
+        <value labelId="REC_NBR" type="http://gedcomx.org/Original">
+          <text>37749</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REF_ID">
+        <value labelId="REF_ID" type="http://gedcomx.org/Original">
+          <text>26</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RELATIONSHIP_CODE">
+        <value labelId="RELATIONSHIP_CODE" type="http://gedcomx.org/Original">
+          <text>DAU</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SHEET_LTR">
+        <value labelId="SHEET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SORT_KEY">
+        <value labelId="SORT_KEY" type="http://gedcomx.org/Original">
+          <text>000000000_004115262_00782_025_000464785025</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UDE_BATCH_NUMBER">
+        <value labelId="UDE_BATCH_NUMBER" type="http://gedcomx.org/Original">
+          <text>N00675-2</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UNIQUE_IDENTIFIER">
+        <value labelId="UNIQUE_IDENTIFIER" type="http://gedcomx.org/Original">
+          <text>464785025</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Age">
+        <value labelId="PR_AGE_ORIG" type="http://gedcomx.org/Original">
+          <text>10y</text>
+        </value>
+        <value labelId="PR_AGE" type="http://gedcomx.org/Interpreted">
+          <text>10</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Race">
+        <value labelId="PR_RACE_OR_COLOR_ORIG" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+        <value labelId="PR_RACE_OR_COLOR" type="http://gedcomx.org/Interpreted">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/RelationshipToHead">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_ORIG" type="http://gedcomx.org/Original">
+          <text>Daughter</text>
+        </value>
+        <value labelId="PR_RELATIONSHIP_TO_HEAD" type="http://gedcomx.org/Interpreted">
+          <text>Daughter</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/FatherBirthPlace">
+        <value labelId="PR_FTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Utah</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/MotherBirthPlace">
+        <value labelId="PR_MTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Utah</text>
+        </value>
+      </field>
+    </person>
+    <person principal="true" id="p_9">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/MMRT-YSC</identifier>
+      <identifier>http://familysearch.org/externalId/easy/record_id/464785026</identifier>
+      <gender type="http://gedcomx.org/Male">
+        <field type="http://gedcomx.org/Gender">
+          <value labelId="PR_SEX_CODE_ORIG" type="http://gedcomx.org/Original">
+            <text>M</text>
+          </value>
+          <value labelId="PR_SEX_CODE" type="http://gedcomx.org/Interpreted">
+            <text>Male</text>
+          </value>
+        </field>
+      </gender>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Mark L Holdaway</fullText>
+          <part type="http://gedcomx.org/Given" value="Mark L">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="PR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Mark L</text>
+              </value>
+              <value labelId="PR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Mark L</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Holdaway">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="PR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Holdaway</text>
+              </value>
+              <value labelId="PR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Holdaway</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="PR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Mark L/Holdaway</text>
+            </value>
+            <value labelId="PR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Mark L Holdaway</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+      <fact type="http://gedcomx.org/Birth">
+        <date>
+          <original>Apr 1894</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="PR_BIRTH_DATE_ORIG" type="http://gedcomx.org/Original">
+              <text>Apr 1894</text>
+            </value>
+            <value labelId="PR_BIRTH_DATE" type="http://gedcomx.org/Interpreted">
+              <text>Apr 1894</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Year">
+            <value labelId="PR_BIRTH_YEAR_ORIG" type="http://gedcomx.org/Original">
+              <text>1894</text>
+            </value>
+            <value labelId="PR_BIRTH_YEAR" type="http://gedcomx.org/Interpreted">
+              <text>1894</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Month">
+            <value labelId="PR_BIRTH_MONTH" type="http://gedcomx.org/Interpreted">
+              <text>Apr</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>Utah</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="PR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact primary="true" type="http://gedcomx.org/Census">
+        <date>
+          <original>1900</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="EVENT_DATE" type="http://gedcomx.org/Interpreted">
+              <text>1900</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="EVENT_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_4" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_3" type="http://gedcomx.org/Interpreted">
+              <text>Uintah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_2" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_1" type="http://gedcomx.org/Interpreted">
+              <text>United States</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact type="http://gedcomx.org/MaritalStatus">
+        <value>Single</value>
+        <field type="http://gedcomx.org/MaritalStatus">
+          <value labelId="PR_MARITAL_STATUS_ORIG" type="http://gedcomx.org/Original">
+            <text>S</text>
+          </value>
+          <value labelId="PR_MARITAL_STATUS" type="http://gedcomx.org/Interpreted">
+            <text>Single</text>
+          </value>
+        </field>
+      </fact>
+      <field type="http://familysearch.org/types/fields/BATCH_ID">
+        <value labelId="BATCH_ID" type="http://gedcomx.org/Original">
+          <text>461419</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/BATCH_LOCALITY">
+        <value labelId="BATCH_LOCALITY" type="http://gedcomx.org/Original">
+          <text>Utah, United States</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/COLLECTION_ID">
+        <value labelId="COLLECTION_ID" type="http://gedcomx.org/Original">
+          <text>1325221</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/DIGITAL_GS_NUMBER">
+        <value labelId="DIGITAL_GS_NUMBER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_1_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_1_TYPE" type="http://gedcomx.org/Original">
+          <text>Country</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_2_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_2_TYPE" type="http://gedcomx.org/Original">
+          <text>State</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_3_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_3_TYPE" type="http://gedcomx.org/Original">
+          <text>County</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_4_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_4_TYPE" type="http://gedcomx.org/Original">
+          <text>Town</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_TYPE">
+        <value labelId="EVENT_TYPE" type="http://gedcomx.org/Original">
+          <text>Census</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FILM_NUMBER">
+        <value labelId="FILM_NUMBER" type="http://gedcomx.org/Original">
+          <text>1241687</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER">
+        <value labelId="FOLDER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER_IMAGE_SEQ">
+        <value labelId="FOLDER_IMAGE_SEQ" type="http://gedcomx.org/Original">
+          <text>782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/HOUSEHOLD_ID">
+        <value labelId="HOUSEHOLD_ID" type="http://gedcomx.org/Original">
+          <text>73</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_APID">
+        <value labelId="IMAGE_APID" type="http://gedcomx.org/Original">
+          <text>TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_ID">
+        <value labelId="IMAGE_ID" type="http://gedcomx.org/Original">
+          <text>/004115262/004115262_00782.jpg</text>
+        </value>
+        <value labelId="IMAGE_ID_NORM" type="http://gedcomx.org/Interpreted">
+          <text>dgs:004115262.004115262_00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_NBR">
+        <value labelId="IMAGE_NBR" type="http://gedcomx.org/Original">
+          <text>00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_PAL">
+        <value labelId="IMAGE_PAL" type="http://gedcomx.org/Original">
+          <text>https://familysearch.org/pal:/MM9.3.1/TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PACKET_LTR">
+        <value labelId="PACKET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PAGE">
+        <value labelId="PAGE" type="http://gedcomx.org/Original">
+          <text>4</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PPQ_ID">
+        <value labelId="PPQ_ID" type="http://gedcomx.org/Original">
+          <text>12-0679</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_ETHNICITY_CSS">
+        <value labelId="PR_ETHNICITY_CSS" type="http://gedcomx.org/Original">
+          <text>American</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RACE_OR_COLOR_CSS">
+        <value labelId="PR_RACE_OR_COLOR_CSS" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RELATIONSHIP_TO_HEAD_CSS">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_CSS" type="http://gedcomx.org/Original">
+          <text>Son</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_GROUP">
+        <value labelId="RECORD_GROUP" type="http://gedcomx.org/Original">
+          <text>; 11-APR-2012 15:47:12.242092; Default</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_ID">
+        <value labelId="RECORD_ID" type="http://gedcomx.org/Original">
+          <text>004115262_00782_26</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REC_NBR">
+        <value labelId="REC_NBR" type="http://gedcomx.org/Original">
+          <text>37750</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REF_ID">
+        <value labelId="REF_ID" type="http://gedcomx.org/Original">
+          <text>27</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RELATIONSHIP_CODE">
+        <value labelId="RELATIONSHIP_CODE" type="http://gedcomx.org/Original">
+          <text>SON</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SHEET_LTR">
+        <value labelId="SHEET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SORT_KEY">
+        <value labelId="SORT_KEY" type="http://gedcomx.org/Original">
+          <text>000000000_004115262_00782_026_000464785026</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UDE_BATCH_NUMBER">
+        <value labelId="UDE_BATCH_NUMBER" type="http://gedcomx.org/Original">
+          <text>N00675-2</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UNIQUE_IDENTIFIER">
+        <value labelId="UNIQUE_IDENTIFIER" type="http://gedcomx.org/Original">
+          <text>464785026</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Age">
+        <value labelId="PR_AGE_ORIG" type="http://gedcomx.org/Original">
+          <text>6y</text>
+        </value>
+        <value labelId="PR_AGE" type="http://gedcomx.org/Interpreted">
+          <text>6</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Race">
+        <value labelId="PR_RACE_OR_COLOR_ORIG" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+        <value labelId="PR_RACE_OR_COLOR" type="http://gedcomx.org/Interpreted">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/RelationshipToHead">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_ORIG" type="http://gedcomx.org/Original">
+          <text>Son</text>
+        </value>
+        <value labelId="PR_RELATIONSHIP_TO_HEAD" type="http://gedcomx.org/Interpreted">
+          <text>Son</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/FatherBirthPlace">
+        <value labelId="PR_FTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Utah</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/MotherBirthPlace">
+        <value labelId="PR_MTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Utah</text>
+        </value>
+      </field>
+    </person>
+    <person principal="true" id="p_10">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/MMRT-YSZ</identifier>
+      <identifier>http://familysearch.org/externalId/easy/record_id/464785028</identifier>
+      <gender type="http://gedcomx.org/Female">
+        <field type="http://gedcomx.org/Gender">
+          <value labelId="PR_SEX_CODE_ORIG" type="http://gedcomx.org/Original">
+            <text>F</text>
+          </value>
+          <value labelId="PR_SEX_CODE" type="http://gedcomx.org/Interpreted">
+            <text>Female</text>
+          </value>
+        </field>
+      </gender>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Hattie Z Holdaway</fullText>
+          <part type="http://gedcomx.org/Given" value="Hattie Z">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="PR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Hattie Z</text>
+              </value>
+              <value labelId="PR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Hattie Z</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Holdaway">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="PR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Holdaway</text>
+              </value>
+              <value labelId="PR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Holdaway</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="PR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Hattie Z/Holdaway</text>
+            </value>
+            <value labelId="PR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Hattie Z Holdaway</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+      <fact type="http://gedcomx.org/Birth">
+        <date>
+          <original>Sep 1896</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="PR_BIRTH_DATE_ORIG" type="http://gedcomx.org/Original">
+              <text>Sep 1896</text>
+            </value>
+            <value labelId="PR_BIRTH_DATE" type="http://gedcomx.org/Interpreted">
+              <text>Sep 1896</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Year">
+            <value labelId="PR_BIRTH_YEAR_ORIG" type="http://gedcomx.org/Original">
+              <text>1896</text>
+            </value>
+            <value labelId="PR_BIRTH_YEAR" type="http://gedcomx.org/Interpreted">
+              <text>1896</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Month">
+            <value labelId="PR_BIRTH_MONTH" type="http://gedcomx.org/Interpreted">
+              <text>Sep</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>Utah</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="PR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact primary="true" type="http://gedcomx.org/Census">
+        <date>
+          <original>1900</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="EVENT_DATE" type="http://gedcomx.org/Interpreted">
+              <text>1900</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="EVENT_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_4" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_3" type="http://gedcomx.org/Interpreted">
+              <text>Uintah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_2" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_1" type="http://gedcomx.org/Interpreted">
+              <text>United States</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact type="http://gedcomx.org/MaritalStatus">
+        <value>Single</value>
+        <field type="http://gedcomx.org/MaritalStatus">
+          <value labelId="PR_MARITAL_STATUS_ORIG" type="http://gedcomx.org/Original">
+            <text>S</text>
+          </value>
+          <value labelId="PR_MARITAL_STATUS" type="http://gedcomx.org/Interpreted">
+            <text>Single</text>
+          </value>
+        </field>
+      </fact>
+      <field type="http://familysearch.org/types/fields/BATCH_ID">
+        <value labelId="BATCH_ID" type="http://gedcomx.org/Original">
+          <text>461419</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/BATCH_LOCALITY">
+        <value labelId="BATCH_LOCALITY" type="http://gedcomx.org/Original">
+          <text>Utah, United States</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/COLLECTION_ID">
+        <value labelId="COLLECTION_ID" type="http://gedcomx.org/Original">
+          <text>1325221</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/DIGITAL_GS_NUMBER">
+        <value labelId="DIGITAL_GS_NUMBER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_1_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_1_TYPE" type="http://gedcomx.org/Original">
+          <text>Country</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_2_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_2_TYPE" type="http://gedcomx.org/Original">
+          <text>State</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_3_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_3_TYPE" type="http://gedcomx.org/Original">
+          <text>County</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_4_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_4_TYPE" type="http://gedcomx.org/Original">
+          <text>Town</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_TYPE">
+        <value labelId="EVENT_TYPE" type="http://gedcomx.org/Original">
+          <text>Census</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FILM_NUMBER">
+        <value labelId="FILM_NUMBER" type="http://gedcomx.org/Original">
+          <text>1241687</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER">
+        <value labelId="FOLDER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER_IMAGE_SEQ">
+        <value labelId="FOLDER_IMAGE_SEQ" type="http://gedcomx.org/Original">
+          <text>782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/HOUSEHOLD_ID">
+        <value labelId="HOUSEHOLD_ID" type="http://gedcomx.org/Original">
+          <text>73</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_APID">
+        <value labelId="IMAGE_APID" type="http://gedcomx.org/Original">
+          <text>TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_ID">
+        <value labelId="IMAGE_ID" type="http://gedcomx.org/Original">
+          <text>/004115262/004115262_00782.jpg</text>
+        </value>
+        <value labelId="IMAGE_ID_NORM" type="http://gedcomx.org/Interpreted">
+          <text>dgs:004115262.004115262_00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_NBR">
+        <value labelId="IMAGE_NBR" type="http://gedcomx.org/Original">
+          <text>00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_PAL">
+        <value labelId="IMAGE_PAL" type="http://gedcomx.org/Original">
+          <text>https://familysearch.org/pal:/MM9.3.1/TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PACKET_LTR">
+        <value labelId="PACKET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PAGE">
+        <value labelId="PAGE" type="http://gedcomx.org/Original">
+          <text>4</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PPQ_ID">
+        <value labelId="PPQ_ID" type="http://gedcomx.org/Original">
+          <text>12-0679</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_ETHNICITY_CSS">
+        <value labelId="PR_ETHNICITY_CSS" type="http://gedcomx.org/Original">
+          <text>American</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RACE_OR_COLOR_CSS">
+        <value labelId="PR_RACE_OR_COLOR_CSS" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RELATIONSHIP_TO_HEAD_CSS">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_CSS" type="http://gedcomx.org/Original">
+          <text>Daughter</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_GROUP">
+        <value labelId="RECORD_GROUP" type="http://gedcomx.org/Original">
+          <text>; 11-APR-2012 15:47:12.242092; Default</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_ID">
+        <value labelId="RECORD_ID" type="http://gedcomx.org/Original">
+          <text>004115262_00782_27</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REC_NBR">
+        <value labelId="REC_NBR" type="http://gedcomx.org/Original">
+          <text>37751</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REF_ID">
+        <value labelId="REF_ID" type="http://gedcomx.org/Original">
+          <text>28</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RELATIONSHIP_CODE">
+        <value labelId="RELATIONSHIP_CODE" type="http://gedcomx.org/Original">
+          <text>DAU</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SHEET_LTR">
+        <value labelId="SHEET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SORT_KEY">
+        <value labelId="SORT_KEY" type="http://gedcomx.org/Original">
+          <text>000000000_004115262_00782_027_000464785028</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UDE_BATCH_NUMBER">
+        <value labelId="UDE_BATCH_NUMBER" type="http://gedcomx.org/Original">
+          <text>N00675-2</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UNIQUE_IDENTIFIER">
+        <value labelId="UNIQUE_IDENTIFIER" type="http://gedcomx.org/Original">
+          <text>464785028</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Age">
+        <value labelId="PR_AGE_ORIG" type="http://gedcomx.org/Original">
+          <text>4y</text>
+        </value>
+        <value labelId="PR_AGE" type="http://gedcomx.org/Interpreted">
+          <text>4</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Race">
+        <value labelId="PR_RACE_OR_COLOR_ORIG" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+        <value labelId="PR_RACE_OR_COLOR" type="http://gedcomx.org/Interpreted">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/RelationshipToHead">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_ORIG" type="http://gedcomx.org/Original">
+          <text>Daughter</text>
+        </value>
+        <value labelId="PR_RELATIONSHIP_TO_HEAD" type="http://gedcomx.org/Interpreted">
+          <text>Daughter</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/FatherBirthPlace">
+        <value labelId="PR_FTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Utah</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/MotherBirthPlace">
+        <value labelId="PR_MTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Utah</text>
+        </value>
+      </field>
+    </person>
+    <person principal="true" id="p_11">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/MMRT-YS8</identifier>
+      <identifier>http://familysearch.org/externalId/easy/record_id/464785030</identifier>
+      <gender type="http://gedcomx.org/Female">
+        <field type="http://gedcomx.org/Gender">
+          <value labelId="PR_SEX_CODE_ORIG" type="http://gedcomx.org/Original">
+            <text>F</text>
+          </value>
+          <value labelId="PR_SEX_CODE" type="http://gedcomx.org/Interpreted">
+            <text>Female</text>
+          </value>
+        </field>
+      </gender>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Elta M Holdaway</fullText>
+          <part type="http://gedcomx.org/Given" value="Elta M">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="PR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Elta M</text>
+              </value>
+              <value labelId="PR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Elta M</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Holdaway">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="PR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Holdaway</text>
+              </value>
+              <value labelId="PR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Holdaway</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="PR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Elta M/Holdaway</text>
+            </value>
+            <value labelId="PR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Elta M Holdaway</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+      <fact type="http://gedcomx.org/Birth">
+        <date>
+          <original>Apr 1899</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="PR_BIRTH_DATE_ORIG" type="http://gedcomx.org/Original">
+              <text>Apr 1899</text>
+            </value>
+            <value labelId="PR_BIRTH_DATE" type="http://gedcomx.org/Interpreted">
+              <text>Apr 1899</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Year">
+            <value labelId="PR_BIRTH_YEAR_ORIG" type="http://gedcomx.org/Original">
+              <text>1899</text>
+            </value>
+            <value labelId="PR_BIRTH_YEAR" type="http://gedcomx.org/Interpreted">
+              <text>1899</text>
+            </value>
+          </field>
+          <field type="http://gedcomx.org/Month">
+            <value labelId="PR_BIRTH_MONTH" type="http://gedcomx.org/Interpreted">
+              <text>Apr</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>Utah</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="PR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact primary="true" type="http://gedcomx.org/Census">
+        <date>
+          <original>1900</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="EVENT_DATE" type="http://gedcomx.org/Interpreted">
+              <text>1900</text>
+            </value>
+          </field>
+        </date>
+        <place>
+          <original>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</original>
+          <field type="http://gedcomx.org/Place">
+            <value labelId="EVENT_PLACE" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_4" type="http://gedcomx.org/Interpreted">
+              <text>ED 152 Vernal Precinct Vernal town</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_3" type="http://gedcomx.org/Interpreted">
+              <text>Uintah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_2" type="http://gedcomx.org/Interpreted">
+              <text>Utah</text>
+            </value>
+          </field>
+          <field type="http://familysearch.org/types/fields/Other">
+            <value labelId="EVENT_PLACE_LEVEL_1" type="http://gedcomx.org/Interpreted">
+              <text>United States</text>
+            </value>
+          </field>
+        </place>
+      </fact>
+      <fact type="http://gedcomx.org/MaritalStatus">
+        <value>Single</value>
+        <field type="http://gedcomx.org/MaritalStatus">
+          <value labelId="PR_MARITAL_STATUS_ORIG" type="http://gedcomx.org/Original">
+            <text>S</text>
+          </value>
+          <value labelId="PR_MARITAL_STATUS" type="http://gedcomx.org/Interpreted">
+            <text>Single</text>
+          </value>
+        </field>
+      </fact>
+      <field type="http://familysearch.org/types/fields/BATCH_ID">
+        <value labelId="BATCH_ID" type="http://gedcomx.org/Original">
+          <text>461419</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/BATCH_LOCALITY">
+        <value labelId="BATCH_LOCALITY" type="http://gedcomx.org/Original">
+          <text>Utah, United States</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/COLLECTION_ID">
+        <value labelId="COLLECTION_ID" type="http://gedcomx.org/Original">
+          <text>1325221</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/DIGITAL_GS_NUMBER">
+        <value labelId="DIGITAL_GS_NUMBER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_1_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_1_TYPE" type="http://gedcomx.org/Original">
+          <text>Country</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_2_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_2_TYPE" type="http://gedcomx.org/Original">
+          <text>State</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_3_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_3_TYPE" type="http://gedcomx.org/Original">
+          <text>County</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_PLACE_LEVEL_4_TYPE">
+        <value labelId="EVENT_PLACE_LEVEL_4_TYPE" type="http://gedcomx.org/Original">
+          <text>Town</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/EVENT_TYPE">
+        <value labelId="EVENT_TYPE" type="http://gedcomx.org/Original">
+          <text>Census</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FILM_NUMBER">
+        <value labelId="FILM_NUMBER" type="http://gedcomx.org/Original">
+          <text>1241687</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER">
+        <value labelId="FOLDER" type="http://gedcomx.org/Original">
+          <text>004115262</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/FOLDER_IMAGE_SEQ">
+        <value labelId="FOLDER_IMAGE_SEQ" type="http://gedcomx.org/Original">
+          <text>782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/HOUSEHOLD_ID">
+        <value labelId="HOUSEHOLD_ID" type="http://gedcomx.org/Original">
+          <text>73</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_APID">
+        <value labelId="IMAGE_APID" type="http://gedcomx.org/Original">
+          <text>TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_ID">
+        <value labelId="IMAGE_ID" type="http://gedcomx.org/Original">
+          <text>/004115262/004115262_00782.jpg</text>
+        </value>
+        <value labelId="IMAGE_ID_NORM" type="http://gedcomx.org/Interpreted">
+          <text>dgs:004115262.004115262_00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_NBR">
+        <value labelId="IMAGE_NBR" type="http://gedcomx.org/Original">
+          <text>00782</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/IMAGE_PAL">
+        <value labelId="IMAGE_PAL" type="http://gedcomx.org/Original">
+          <text>https://familysearch.org/pal:/MM9.3.1/TH-267-11392-19378-95</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PACKET_LTR">
+        <value labelId="PACKET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PAGE">
+        <value labelId="PAGE" type="http://gedcomx.org/Original">
+          <text>4</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PPQ_ID">
+        <value labelId="PPQ_ID" type="http://gedcomx.org/Original">
+          <text>12-0679</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_ETHNICITY_CSS">
+        <value labelId="PR_ETHNICITY_CSS" type="http://gedcomx.org/Original">
+          <text>American</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RACE_OR_COLOR_CSS">
+        <value labelId="PR_RACE_OR_COLOR_CSS" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/PR_RELATIONSHIP_TO_HEAD_CSS">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_CSS" type="http://gedcomx.org/Original">
+          <text>Daughter</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_GROUP">
+        <value labelId="RECORD_GROUP" type="http://gedcomx.org/Original">
+          <text>; 11-APR-2012 15:47:12.242092; Default</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RECORD_ID">
+        <value labelId="RECORD_ID" type="http://gedcomx.org/Original">
+          <text>004115262_00782_28</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REC_NBR">
+        <value labelId="REC_NBR" type="http://gedcomx.org/Original">
+          <text>37752</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/REF_ID">
+        <value labelId="REF_ID" type="http://gedcomx.org/Original">
+          <text>29</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/RELATIONSHIP_CODE">
+        <value labelId="RELATIONSHIP_CODE" type="http://gedcomx.org/Original">
+          <text>DAU</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SHEET_LTR">
+        <value labelId="SHEET_LTR" type="http://gedcomx.org/Original">
+          <text>A</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/SORT_KEY">
+        <value labelId="SORT_KEY" type="http://gedcomx.org/Original">
+          <text>000000000_004115262_00782_028_000464785030</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UDE_BATCH_NUMBER">
+        <value labelId="UDE_BATCH_NUMBER" type="http://gedcomx.org/Original">
+          <text>N00675-2</text>
+        </value>
+      </field>
+      <field type="http://familysearch.org/types/fields/UNIQUE_IDENTIFIER">
+        <value labelId="UNIQUE_IDENTIFIER" type="http://gedcomx.org/Original">
+          <text>464785030</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Age">
+        <value labelId="PR_AGE_ORIG" type="http://gedcomx.org/Original">
+          <text>1y</text>
+        </value>
+        <value labelId="PR_AGE" type="http://gedcomx.org/Interpreted">
+          <text>1</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/Race">
+        <value labelId="PR_RACE_OR_COLOR_ORIG" type="http://gedcomx.org/Original">
+          <text>White</text>
+        </value>
+        <value labelId="PR_RACE_OR_COLOR" type="http://gedcomx.org/Interpreted">
+          <text>White</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/RelationshipToHead">
+        <value labelId="PR_RELATIONSHIP_TO_HEAD_ORIG" type="http://gedcomx.org/Original">
+          <text>Daughter</text>
+        </value>
+        <value labelId="PR_RELATIONSHIP_TO_HEAD" type="http://gedcomx.org/Interpreted">
+          <text>Daughter</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/FatherBirthPlace">
+        <value labelId="PR_FTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Utah</text>
+        </value>
+      </field>
+      <field type="http://gedcomx.org/MotherBirthPlace">
+        <value labelId="PR_MTHR_BIRTH_PLACE" type="http://gedcomx.org/Interpreted">
+          <text>Utah</text>
+        </value>
+      </field>
+    </person>
+    <relationship type="http://gedcomx.org/Couple">
+      <person1 resource="#p_5"/>
+      <person2 resource="#p_6"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_5"/>
+      <person2 resource="#p_7"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_6"/>
+      <person2 resource="#p_7"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_5"/>
+      <person2 resource="#p_8"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_6"/>
+      <person2 resource="#p_8"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_5"/>
+      <person2 resource="#p_9"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_6"/>
+      <person2 resource="#p_9"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_5"/>
+      <person2 resource="#p_10"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_6"/>
+      <person2 resource="#p_10"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_5"/>
+      <person2 resource="#p_11"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_6"/>
+      <person2 resource="#p_11"/>
+    </relationship>
+    <sourceDescription about="https://familysearch.org/pal:/MM9.1.2/1BK1-C7K" resourceType="http://gedcomx.org/Record" id="s5">
+      <citation>
+        <value>"United States Census, 1900," index and images, &lt;i&gt;FamilySearch&lt;/i&gt;
+          (https://familysearch.org/pal:/MM9.1.2/1BK1-C7K : accessed 17 Apr 2013), Thomas Holdaway, 1900.
+        </value>
+      </citation>
+      <source description="#s2"/>
+      <componentOf description="#s3"/>
+      <title xml:lang="en-US">Household of Thomas Holdaway, "United States Census, 1900"</title>
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.2/1BK1-C7K</identifier>
+      <created>2012-06-06T18:00:00-06:00</created>
+      <modified>2012-06-06T18:00:00-06:00</modified>
+      <coverage>
+        <recordType>http://gedcomx.org/Census</recordType>
+        <spatial>
+          <original>ED 152 Vernal Precinct Vernal town, Uintah, Utah, United States</original>
+        </spatial>
+        <temporal>
+          <original>1900</original>
+          <formal>+1900</formal>
+        </temporal>
+      </coverage>
+      <descriptor resource="https://familysearch.org/records/collections/1325221#rd_1325221"/>
+    </sourceDescription>
+    <sourceDescription about="https://familysearch.org/records/collection/1325221/records" resourceType="http://familysearch.org/types/facts/Container" id="s3">
+      <componentOf description="#s4"/>
+      <title xml:lang="en-US">United States Census, 1900</title>
+      <identifier type="http://gedcomx.org/Primary">https://familysearch.org/records/collection/1325221/records</identifier>
+    </sourceDescription>
+    <sourceDescription about="https://familysearch.org/records/collection/1325221" resourceType="http://gedcomx.org/Collection" id="s4">
+      <title xml:lang="en-US">United States Census, 1900</title>
+      <identifier type="http://gedcomx.org/Primary">https://familysearch.org/records/collection/1325221</identifier>
+    </sourceDescription>
+    <sourceDescription about="https://familysearch.org/pal:/MM9.3.1/TH-267-11392-19378-95?cc=1325221" resourceType="http://gedcomx.org/DigitalArtifact" id="s2">
+      <attribution>
+        <contributor resource="#a2"/>
+      </attribution>
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.3.1/TH-267-11392-19378-95?cc=1325221</identifier>
+    </sourceDescription>
+    <agent id="a2">
+      <name>familysearch.org</name>
+    </agent>
+  </record>
+  <record description="#s6" xml:lang="en-US" id="r_731503667">
+    <person principal="true" id="p_12">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/F8GH-D48</identifier>
+      <gender type="http://gedcomx.org/Female"/>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Thelma Myrl Holdsway</fullText>
+          <part type="http://gedcomx.org/Given" value="Thelma Myrl">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="BR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Thelma Myrl</text>
+              </value>
+              <value labelId="BR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Thelma Myrl</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Holdsway">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="BR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Holdsway</text>
+              </value>
+              <value labelId="BR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Holdsway</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="BR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Thelma Myrl/Holdsway</text>
+            </value>
+            <value labelId="BR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Thelma Myrl Holdsway</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+    </person>
+    <person id="p_13">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/F8GH-D4D</identifier>
+      <gender type="http://gedcomx.org/Male"/>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Thos. T. Holdsway</fullText>
+          <part type="http://gedcomx.org/Given" value="Thos. T.">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="BR_FTHR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Thos. T.</text>
+              </value>
+              <value labelId="BR_FTHR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Thos. T.</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Holdsway">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="BR_FTHR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Holdsway</text>
+              </value>
+              <value labelId="BR_FTHR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Holdsway</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="BR_FTHR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Thos. T./Holdsway</text>
+            </value>
+            <value labelId="BR_FTHR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Thos. T. Holdsway</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+    </person>
+    <person id="p_14">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/F8GH-D46</identifier>
+      <gender type="http://gedcomx.org/Female"/>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Mary E. White</fullText>
+          <part type="http://gedcomx.org/Given" value="Mary E.">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="BR_MTHR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Mary E.</text>
+              </value>
+              <value labelId="BR_MTHR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Mary E.</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="White">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="BR_MTHR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>White</text>
+              </value>
+              <value labelId="BR_MTHR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>White</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="BR_MTHR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Mary E./White</text>
+            </value>
+            <value labelId="BR_MTHR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Mary E. White</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+    </person>
+    <person principal="true" id="p_15">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/F8GH-D4X</identifier>
+      <gender type="http://gedcomx.org/Male"/>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Malcolm Hendricks Merrill</fullText>
+          <part type="http://gedcomx.org/Given" value="Malcolm Hendricks">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="GR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Malcolm Hendricks</text>
+              </value>
+              <value labelId="GR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Malcolm Hendricks</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Merrill">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="GR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Merrill</text>
+              </value>
+              <value labelId="GR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Merrill</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="GR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Malcolm Hendricks/Merrill</text>
+            </value>
+            <value labelId="GR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Malcolm Hendricks Merrill</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+    </person>
+    <person id="p_16">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/F8GH-D4F</identifier>
+      <gender type="http://gedcomx.org/Male"/>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>L.Edgar Merrill</fullText>
+          <part type="http://gedcomx.org/Given" value="L.Edgar">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="GR_FTHR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>L.Edgar</text>
+              </value>
+              <value labelId="GR_FTHR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>L.Edgar</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Merrill">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="GR_FTHR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Merrill</text>
+              </value>
+              <value labelId="GR_FTHR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Merrill</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="GR_FTHR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>L.Edgar/Merrill</text>
+            </value>
+            <value labelId="GR_FTHR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>L.Edgar Merrill</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+    </person>
+    <person id="p_17">
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.1/F8GH-D4N</identifier>
+      <gender type="http://gedcomx.org/Female"/>
+      <name type="http://gedcomx.org/BirthName">
+        <nameForm>
+          <fullText>Clara Hendricks</fullText>
+          <part type="http://gedcomx.org/Given" value="Clara">
+            <field type="http://gedcomx.org/Given">
+              <value labelId="GR_MTHR_NAME_GN_ORIG" type="http://gedcomx.org/Original">
+                <text>Clara</text>
+              </value>
+              <value labelId="GR_MTHR_NAME_GN" type="http://gedcomx.org/Interpreted">
+                <text>Clara</text>
+              </value>
+            </field>
+          </part>
+          <part type="http://gedcomx.org/Surname" value="Hendricks">
+            <field type="http://gedcomx.org/Surname">
+              <value labelId="GR_MTHR_NAME_SURN_ORIG" type="http://gedcomx.org/Original">
+                <text>Hendricks</text>
+              </value>
+              <value labelId="GR_MTHR_NAME_SURN" type="http://gedcomx.org/Interpreted">
+                <text>Hendricks</text>
+              </value>
+            </field>
+          </part>
+          <field type="http://gedcomx.org/Name">
+            <value labelId="GR_MTHR_NAME_ORIG" type="http://gedcomx.org/Original">
+              <text>Clara/Hendricks</text>
+            </value>
+            <value labelId="GR_MTHR_NAME" type="http://gedcomx.org/Interpreted">
+              <text>Clara Hendricks</text>
+            </value>
+          </field>
+        </nameForm>
+      </name>
+    </person>
+    <relationship type="http://gedcomx.org/Couple">
+      <person1 resource="#p_15"/>
+      <person2 resource="#p_12"/>
+      <fact primary="true" type="http://gedcomx.org/Marriage">
+        <date>
+          <original>09 Aug 1926</original>
+          <field type="http://gedcomx.org/Date">
+            <value labelId="MARRIAGE_DATE_STD" type="http://gedcomx.org/Interpreted">
+              <text>09 Aug 1926</text>
+            </value>
+          </field>
+        </date>
+      </fact>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_13"/>
+      <person2 resource="#p_12"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_14"/>
+      <person2 resource="#p_12"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/Couple">
+      <person1 resource="#p_13"/>
+      <person2 resource="#p_14"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_16"/>
+      <person2 resource="#p_15"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/ParentChild">
+      <person1 resource="#p_17"/>
+      <person2 resource="#p_15"/>
+    </relationship>
+    <relationship type="http://gedcomx.org/Couple">
+      <person1 resource="#p_16"/>
+      <person2 resource="#p_17"/>
+    </relationship>
+    <sourceDescription about="https://familysearch.org/pal:/MM9.1.2/9M3S-LRJ" resourceType="http://gedcomx.org/Record" id="s6">
+      <citation>
+        <value>"Utah, Marriages, 1887-1966," index, &lt;i&gt;FamilySearch&lt;/i&gt;
+          (https://familysearch.org/pal:/MM9.1.2/9M3S-LRJ : accessed 03 Jul 2013), Malcolm Hendricks Merrill and Thelma Myrl
+          Holdsway, 09 Aug 1926.
+        </value>
+      </citation>
+      <componentOf description="#s3"/>
+      <title xml:lang="en-US">Entry for Malcolm Hendricks Merrill and Thelma Myrl Holdsway, "Utah, Marriages,
+        1887-1966"
+      </title>
+      <identifier type="http://gedcomx.org/Persistent">https://familysearch.org/pal:/MM9.1.2/9M3S-LRJ</identifier>
+      <identifier>http://familysearch.org/externalId/easy/record_id/200163360</identifier>
+      <created>2010-04-07T18:00:00-06:00</created>
+      <modified>2011-08-30T18:00:00-06:00</modified>
+      <coverage>
+        <recordType>http://gedcomx.org/Marriage</recordType>
+        <temporal>
+          <original>09 Aug 1926</original>
+        </temporal>
+      </coverage>
+      <descriptor resource="https://familysearch.org/records/collections/1675546#rd_1675546"/>
+    </sourceDescription>
+    <sourceDescription about="https://familysearch.org/records/collection/1675546/records" resourceType="http://familysearch.org/types/facts/Container" id="s3">
+      <componentOf description="#s4"/>
+      <title xml:lang="en-US">Utah, Marriages, 1887-1966</title>
+      <identifier type="http://gedcomx.org/Primary">https://familysearch.org/records/collection/1675546/records</identifier>
+    </sourceDescription>
+    <sourceDescription about="https://familysearch.org/records/collection/1675546" resourceType="http://gedcomx.org/Collection" id="s4">
+      <title xml:lang="en-US">Utah, Marriages, 1887-1966</title>
+      <identifier type="http://gedcomx.org/Primary">https://familysearch.org/records/collection/1675546</identifier>
+    </sourceDescription>
+    <field type="http://familysearch.org/types/fields/BATCH_LOCALITY">
+      <value labelId="BATCH_LOCALITY" type="http://gedcomx.org/Original">
+        <text>Cache, Utah, United States</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/DIGITAL_GS_NUMBER">
+      <value labelId="DIGITAL_GS_NUMBER" type="http://gedcomx.org/Original">
+        <text>4282917</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/EVENT_DATE_ORIG">
+      <value labelId="EVENT_DATE_ORIG" type="http://gedcomx.org/Original">
+        <text>9Aug1926</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/EVENT_TYPE_ORIG">
+      <value labelId="EVENT_TYPE_ORIG" type="http://gedcomx.org/Original">
+        <text>marriage</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/EVENT_TYPE_STD">
+      <value labelId="EVENT_TYPE_STD" type="http://gedcomx.org/Original">
+        <text>Marriage</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/EVENT_YEAR">
+      <value labelId="EVENT_YEAR" type="http://gedcomx.org/Original">
+        <text>1926</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/FILM_NUMBER">
+      <value labelId="FILM_NUMBER" type="http://gedcomx.org/Original">
+        <text>430322</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/FOLDER">
+      <value labelId="FOLDER" type="http://gedcomx.org/Original">
+        <text>000430322</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/FOLDER_IMAGE_SEQ">
+      <value labelId="FOLDER_IMAGE_SEQ" type="http://gedcomx.org/Original">
+        <text>911</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/IMAGE_ID">
+      <value labelId="IMAGE_ID" type="http://gedcomx.org/Original">
+        <text>dgs:000430322.000430322_00911</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/IMAGE_NBR">
+      <value labelId="IMAGE_NBR" type="http://gedcomx.org/Original">
+        <text>911</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/PACKET_LTR">
+      <value labelId="PACKET_LTR" type="http://gedcomx.org/Original">
+        <text>C</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/RECORD_GROUP">
+      <value labelId="RECORD_GROUP" type="http://gedcomx.org/Original">
+        <text>Utah-EASy</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/RECORD_PLACE">
+      <value labelId="RECORD_PLACE" type="http://gedcomx.org/Original">
+        <text>Cache, Utah, United States</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/REC_NBR">
+      <value labelId="REC_NBR" type="http://gedcomx.org/Original">
+        <text>116</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/REF_ID">
+      <value labelId="REF_ID" type="http://gedcomx.org/Original">
+        <text>248</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/RESIDENCE">
+      <value labelId="RESIDENCE" type="http://gedcomx.org/Original">
+        <text>Cache, Utah, United States</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/UDE_BATCH_NUMBER">
+      <value labelId="UDE_BATCH_NUMBER" type="http://gedcomx.org/Original">
+        <text>I01421-1</text>
+      </value>
+    </field>
+    <field type="http://familysearch.org/types/fields/UNIQUE_IDENTIFIER">
+      <value labelId="UNIQUE_IDENTIFIER" type="http://gedcomx.org/Original">
+        <text>200163360</text>
+      </value>
+    </field>
+  </record>
+</records>


### PR DESCRIPTION
Added RecordSetWriter and RecordSetIterator to support writing and reading RecordSet objects without having to keep all of the records expanded in memory at once. Added CleanXMLStreamWriter to support that.

Added FieldMap to simplify dealing with record and image browse data field values and associated display labels in record descriptors.

Added MarshalUtil to simplify going to/from XML. (Helped with unit tests on the above, and is generally helpful).
