### PR TITLE
Added a "close()" method to RecordSetIterator to close the inputStream. ...

### DIFF
--- a/gedcomx-model/src/main/java/org/gedcomx/util/RecordSetIterator.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/util/RecordSetIterator.java
@@ -62,7 +62,7 @@ public class RecordSetIterator implements Iterator<Gedcomx> {
    * @throws java.io.IOException
    */
   public RecordSetIterator(String filename) throws IOException {
-    this(filename.toLowerCase().endsWith(".gz") ? new GZIPInputStream(new FileInputStream(filename)) : new FileInputStream(filename));
+    this(new FileInputStream(filename), filename.toLowerCase().endsWith(".gz"));
   }
 
   public RecordSetIterator(InputStream inputStream, boolean isGzipped) throws IOException {
@@ -158,4 +158,18 @@ public class RecordSetIterator implements Iterator<Gedcomx> {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Close the input stream and accompanying reader if they are still open.
+   */
+  public void close() throws XMLStreamException, IOException {
+    if (xmlStreamReader != null) {
+      xmlStreamReader.close();
+      xmlStreamReader = null;
+    }
+
+    if (reader != null) {
+      reader.close();
+      reader = null;
+    }
+  }
 }

--- a/gedcomx-model/src/test/java/org/gedcomx/util/TestRecordSetIterator.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/util/TestRecordSetIterator.java
@@ -8,6 +8,7 @@ import org.gedcomx.Gedcomx;
 import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.Iterator;
 
 /**
@@ -35,6 +36,7 @@ public class TestRecordSetIterator extends TestCase {
     assertFalse(recordIterator.hasNext());
     assertNull(recordIterator.next());
     assertNull(recordIterator.next());
+    inputStream.close();
   }
 
   public void testParserWithMetadata() throws IOException, XMLStreamException {
@@ -63,5 +65,21 @@ public class TestRecordSetIterator extends TestCase {
     assertNull(recordIterator.next());
     assertNull(recordIterator.next());
     assertNotNull(recordIterator.getMetadata());
+    recordIterator.close();
+  }
+
+  public void testClose() throws IOException, XMLStreamException {
+    URL url = getClass().getClassLoader().getResource("gedcomx-recordset2.xml");
+    RecordSetIterator recordIterator = new RecordSetIterator(url.getFile());
+    assertTrue(recordIterator.hasNext());
+    // Haven't hit it yet.
+    assertNull(recordIterator.getMetadata());
+    Gedcomx record1 = recordIterator.next();
+    // Haven't hit it yet.
+    assertNull(recordIterator.getMetadata());
+    Gedcomx record2 = recordIterator.next();
+
+    // Close it before it reaches the end of the file to test close.
+    recordIterator.close();
   }
 }


### PR DESCRIPTION
... CDS has a case where we don't read through all entries in RecordSet...just enough to validate a couple records and then pass the file along.  As such, the only place that closed the inputStream previously was in prepareNext() when it reached the end of the file.  Since I don't get to the end of the file, I still need a way to close the inputStreams.