### PR TITLE
correcting FamilySearchReferenceEnvironment.java

### DIFF
--- a/extensions/familysearch/familysearch-api-client/src/main/java/org/familysearch/api/client/FamilySearchReferenceEnvironment.java
+++ b/extensions/familysearch/familysearch-api-client/src/main/java/org/familysearch/api/client/FamilySearchReferenceEnvironment.java
@@ -51,6 +51,6 @@ public enum FamilySearchReferenceEnvironment {
   }
 
   public URI getFamilyTreeUri() {
-    return URI.create(this.base + "/collections/places");
+    return URI.create(this.base + "/collections/tree");
   }
 }


### PR DESCRIPTION
changing getFamilyTreeUri() to return URI to /collections/tree instead of /collections/places