### PR TITLE
Two new convenience methods for Name and Person

### DIFF
--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Name.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Name.java
@@ -31,6 +31,7 @@ import org.gedcomx.rt.json.JsonElementWrapper;
 import org.gedcomx.source.SourceDescription;
 import org.gedcomx.source.SourceReference;
 import org.gedcomx.types.ConfidenceLevel;
+import org.gedcomx.types.NamePartType;
 import org.gedcomx.types.NameType;
 
 import javax.xml.bind.annotation.*;
@@ -307,6 +308,27 @@ public class Name extends Conclusion {
   public Name preferred(Boolean preferred) {
     setPreferred(preferred);
     return this;
+  }
+
+  /**
+   * Gets a specific part of the name
+   * @param namePartType specific part of the name to retrieve
+   * @return the specific part of the name that matches the given NamePartType
+   */
+  public String getPart(NamePartType namePartType) {
+    if(this.nameForms == null || this.nameForms.isEmpty() ||
+      this.nameForms.get(0) == null ||
+      this.nameForms.get(0).getParts() == null) {
+      return null;
+    }
+
+    for(NamePart namePart : this.nameForms.get(0).getParts()) {
+      if(namePart.getKnownType() == namePartType) {
+        return namePart.getValue();
+      }
+    }
+
+    return null;
   }
 
   @Override

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Person.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Person.java
@@ -370,6 +370,28 @@ public class Person extends Subject implements HasFacts, HasFields {
   }
 
   /**
+   * Get the preferred name of the person. If no preferred name is specified, then the first name is returned.
+   *
+   * @return the preferred name of the person or first name if there is no preferred name.
+   */
+  @JsonIgnore
+  public Name getPreferredName() {
+    if(this.names == null || this.names.size() <= 0) {
+      return null;
+    }
+
+    for(Name name : this.names) {
+      if(name.getPreferred() != null) {
+        if(name.getPreferred()) {
+          return name;
+        }
+      }
+    }
+
+    return this.names.get(0);
+  }
+
+  /**
    * The name conclusions for the person.
    *
    * @param names The name conclusions for the person.
@@ -436,13 +458,13 @@ public class Person extends Subject implements HasFacts, HasFields {
     if (this.facts == null) {
       return null;
     }
-    
+
     for (Fact fact : this.facts) {
       if (type.equals(fact.getKnownType())) {
         return fact;
       }
     }
-    
+
     return null;
   }
 
@@ -610,7 +632,7 @@ public class Person extends Subject implements HasFacts, HasFields {
 
   /**
    * Embed the specified person into this one.
-   * 
+   *
    * @param person The person to embed.
    */
   public void embed(Person person) {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Person.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Person.java
@@ -374,6 +374,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    *
    * @return the preferred name of the person or first name if there is no preferred name.
    */
+  @XmlTransient
   @JsonIgnore
   public Name getPreferredName() {
     if(this.names == null || this.names.size() <= 0) {

--- a/gedcomx-model/src/test/java/org/gedcomx/conclusion/PersonTest.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/conclusion/PersonTest.java
@@ -95,6 +95,14 @@ public class PersonTest {
     assertNull(person.getFirstNameOfType(NameType.FormalName));
   }
 
+  public void testPersonGetPreferredName() throws Exception {
+    Person person = create();
+    assertPersonEquals(person);
+    assertEquals("type=FormalName,nameForms[0]=primary form,pref=true", person.getPreferredName().toString());
+    person.setNames(null);
+    assertNull(person.getPreferredName());
+  }
+
   public void testFactHelpers() throws Exception {
     Fact fact = new Fact();
 

--- a/gedcomx-model/src/test/java/org/gedcomx/examples/NamesExampleTest.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/examples/NamesExampleTest.java
@@ -11,6 +11,9 @@ import org.gedcomx.types.NamePartQualifierType;
 import org.gedcomx.types.NamePartType;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
 /**
  * @author Ryan Heaton
  */
@@ -90,4 +93,36 @@ public class NamesExampleTest {
     SerializationUtil.processThroughJson(gx);
   }
 
+  public void testGetPart() throws Exception {
+    NameForm nameForm = new NameForm("John Fitzgerald Kennedy")
+      .lang("en")
+      .part(NamePartType.Given, "John")
+      .part(NamePartType.Given, "Fitzgerald")
+      .part(NamePartType.Surname, "Kennedy");
+    Name name = new Name().nameForm(nameForm);
+    assertEquals("John", name.getPart(NamePartType.Given));
+    assertEquals("Kennedy", name.getPart(NamePartType.Surname));
+
+    Name nameNoForms = new Name();
+    assertNull(nameNoForms.getPart(NamePartType.Given));
+    assertNull(nameNoForms.getPart(NamePartType.Surname));
+
+    Name nameNullForm = new Name().nameForm(null);
+    assertNull(nameNullForm.getPart(NamePartType.Given));
+    assertNull(nameNullForm.getPart(NamePartType.Surname));
+
+    NameForm nameFormNoParts = new NameForm("John Fitzgerald Kennedy")
+      .lang("en");
+    Name nameNoParts = new Name().nameForm(nameFormNoParts);
+    assertNull(nameNoParts.getPart(NamePartType.Given));
+    assertNull(nameNoParts.getPart(NamePartType.Surname));
+
+    NameForm nameFormNullParts = new NameForm("John Fitzgerald Kennedy")
+      .lang("en")
+      .part(NamePartType.Given, null)
+      .part(NamePartType.Surname, null);
+    Name nameNullParts = new Name().nameForm(nameFormNullParts);
+    assertNull(nameNullParts.getPart(NamePartType.Given));
+    assertNull(nameNullParts.getPart(NamePartType.Surname));
+  }
 }


### PR DESCRIPTION
 - New getPreferredName() in Person Object
 - New getPart(NamePartType) in Name Object

 This allows for a specific name part of the preferred name to be retrieved more easily. For example, to retrieve the preferred given name for a user:  `person.getPreferredName().getPart(NamePartType.Given);`