### PR TITLE
Add Jackson 1 annotations.

### DIFF
--- a/extensions/familysearch/familysearch-api-model/pom.xml
+++ b/extensions/familysearch/familysearch-api-model/pom.xml
@@ -24,5 +24,11 @@
       <artifactId>gedcomx-atom</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/FamilySearchPlatform.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/FamilySearchPlatform.java
@@ -85,7 +85,7 @@ public class FamilySearchPlatform extends Gedcomx {
    * @return The merge analysis results for this data set.
    */
   @XmlElement ( name = "mergeAnalysis" )
-  @JsonProperty ( "mergeAnalyses" )
+  @JsonProperty ( "mergeAnalyses" ) @org.codehaus.jackson.annotate.JsonProperty ( "mergeAnalyses" )
   public List<MergeAnalysis> getMergeAnalyses() {
     return mergeAnalyses;
   }
@@ -95,7 +95,7 @@ public class FamilySearchPlatform extends Gedcomx {
    *
    * @param mergeAnalyses The merge analysis results for this data set.
    */
-  @JsonProperty ( "mergeAnalyses" )
+  @JsonProperty ( "mergeAnalyses" ) @org.codehaus.jackson.annotate.JsonProperty ( "mergeAnalyses" )
   public void setMergeAnalyses(List<MergeAnalysis> mergeAnalyses) {
     this.mergeAnalyses = mergeAnalyses;
   }
@@ -120,7 +120,7 @@ public class FamilySearchPlatform extends Gedcomx {
    * @return The merges for this data set.
    */
   @XmlElement ( name = "merge" )
-  @JsonProperty ( "merges" )
+  @JsonProperty ( "merges" ) @org.codehaus.jackson.annotate.JsonProperty ( "merges" )
   public List<Merge> getMerges() {
     return merges;
   }
@@ -130,7 +130,7 @@ public class FamilySearchPlatform extends Gedcomx {
    *
    * @param merges The merges for this data set.
    */
-  @JsonProperty ( "merges" )
+  @JsonProperty ( "merges" ) @org.codehaus.jackson.annotate.JsonProperty ( "merges" )
   public void setMerges(List<Merge> merges) {
     this.merges = merges;
   }
@@ -155,7 +155,7 @@ public class FamilySearchPlatform extends Gedcomx {
    * @return The child-and-parents relationships for this data set.
    */
   @XmlElement ( name = "childAndParentsRelationship" )
-  @JsonProperty ( "childAndParentsRelationships" )
+  @JsonProperty ( "childAndParentsRelationships" ) @org.codehaus.jackson.annotate.JsonProperty ( "childAndParentsRelationships" )
   public List<ChildAndParentsRelationship> getChildAndParentsRelationships() {
     return childAndParentsRelationships;
   }
@@ -165,7 +165,7 @@ public class FamilySearchPlatform extends Gedcomx {
    *
    * @param childAndParentsRelationships The child-and-parents relationships for this data set.
    */
-  @JsonProperty ( "childAndParentsRelationships" )
+  @JsonProperty ( "childAndParentsRelationships" ) @org.codehaus.jackson.annotate.JsonProperty ( "childAndParentsRelationships" )
   public void setChildAndParentsRelationships(List<ChildAndParentsRelationship> childAndParentsRelationships) {
     this.childAndParentsRelationships = childAndParentsRelationships;
   }
@@ -214,7 +214,7 @@ public class FamilySearchPlatform extends Gedcomx {
    * @return The discussions included in this data set.
    */
   @XmlElement ( name = "discussion" )
-  @JsonProperty ( "discussions" )
+  @JsonProperty ( "discussions" ) @org.codehaus.jackson.annotate.JsonProperty ( "discussions" )
   public List<Discussion> getDiscussions() {
     return discussions;
   }
@@ -224,7 +224,7 @@ public class FamilySearchPlatform extends Gedcomx {
    *
    * @param discussions The discussions included in this data set.
    */
-  @JsonProperty ( "discussions" )
+  @JsonProperty ( "discussions" ) @org.codehaus.jackson.annotate.JsonProperty ( "discussions" )
   public void setDiscussions(List<Discussion> discussions) {
     this.discussions = discussions;
   }
@@ -260,7 +260,7 @@ public class FamilySearchPlatform extends Gedcomx {
    * @return The users included in this genealogical data set.
    */
   @XmlElement ( name = "user" )
-  @JsonProperty ( "users" )
+  @JsonProperty ( "users" ) @org.codehaus.jackson.annotate.JsonProperty ( "users" )
   public List<User> getUsers() {
     return users;
   }
@@ -270,7 +270,7 @@ public class FamilySearchPlatform extends Gedcomx {
    *
    * @param users The users included in this data set.
    */
-  @JsonProperty ( "users" )
+  @JsonProperty ( "users" ) @org.codehaus.jackson.annotate.JsonProperty ( "users" )
   public void setUsers(List<User> users) {
     this.users = users;
   }
@@ -291,7 +291,7 @@ public class FamilySearchPlatform extends Gedcomx {
    * @return The set of features defined in the platform API.
    */
   @XmlElement ( name = "feature" )
-  @JsonProperty ( "features" )
+  @JsonProperty ( "features" ) @org.codehaus.jackson.annotate.JsonProperty ( "features" )
   public List<Feature> getFeatures() {
     return features;
   }
@@ -301,7 +301,7 @@ public class FamilySearchPlatform extends Gedcomx {
    *
    * @param features The set of features defined in the platform API.
    */
-  @JsonProperty ( "features" )
+  @JsonProperty ( "features" ) @org.codehaus.jackson.annotate.JsonProperty ( "features" )
   public void setFeatures(List<Feature> features) {
     this.features = features;
   }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/artifacts/ArtifactMetadata.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/artifacts/ArtifactMetadata.java
@@ -71,7 +71,7 @@ public class ArtifactMetadata {
    * @return The qualifiers associated with this artifact.
    */
   @XmlElement ( name = "qualifier" )
-  @JsonProperty ( "qualifiers" )
+  @JsonProperty ( "qualifiers" ) @org.codehaus.jackson.annotate.JsonProperty ( "qualifiers" )
   public List<Qualifier> getQualifiers() {
     return qualifiers;
   }
@@ -81,7 +81,7 @@ public class ArtifactMetadata {
    *
    * @param qualifiers qualifiers to associate with this fact.
    */
-  @JsonProperty ( "qualifiers" )
+  @JsonProperty ( "qualifiers" ) @org.codehaus.jackson.annotate.JsonProperty ( "qualifiers" )
   public void setQualifiers(List<Qualifier> qualifiers) {
     this.qualifiers = qualifiers;
   }
@@ -92,7 +92,7 @@ public class ArtifactMetadata {
    * @return The type of the artifact.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public ArtifactType getKnownType() {
     if (this.qualifiers != null) {
       for (Qualifier qualifier : this.qualifiers) {
@@ -114,7 +114,7 @@ public class ArtifactMetadata {
    *
    * @param type The type of the artifact.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(ArtifactType type) {
     this.qualifiers = new ArrayList<Qualifier>(Collections.singletonList(new Qualifier(type)));
   }
@@ -199,7 +199,7 @@ public class ArtifactMetadata {
    * @return The known screening state of the artifact.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public ArtifactScreeningState getKnownScreeningState() {
     return getScreeningState() == null ? null : ArtifactScreeningState.fromQNameURI(getScreeningState());
   }
@@ -209,7 +209,7 @@ public class ArtifactMetadata {
    *
    * @param screeningState The known screening state of the artifact.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownScreeningState(ArtifactScreeningState screeningState) {
     setScreeningState(screeningState == null ? null : screeningState.toQNameURI());
   }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/ChangeInfo.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/ChangeInfo.java
@@ -15,6 +15,7 @@
  */
 package org.familysearch.platform.ct;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.webcohesion.enunciate.metadata.qname.XmlQNameEnumRef;
 import org.gedcomx.common.ResourceReference;
@@ -80,7 +81,7 @@ public class ChangeInfo {
    * @return The enum referencing the known operation of the change.
    */
   @XmlTransient
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public ChangeOperation getKnownOperation() {
     return getOperation() == null ? null : ChangeOperation.fromQNameURI(getOperation());
   }
@@ -90,7 +91,7 @@ public class ChangeInfo {
    *
    * @param knownOperation the change operation.
    */
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownOperation(ChangeOperation knownOperation) {
     setOperation(knownOperation == null ? null : knownOperation.toQNameURI());
   }
@@ -121,7 +122,7 @@ public class ChangeInfo {
    * @return The enum referencing the known object type of the change.
    */
   @XmlTransient
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public ChangeObjectType getKnownObjectType() {
     return getObjectType() == null ? null : ChangeObjectType.fromQNameURI(getObjectType());
   }
@@ -131,7 +132,7 @@ public class ChangeInfo {
    *
    * @param knownObject the change object.
    */
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownObjectType(ChangeObjectType knownObject) {
     setObjectType(knownObject == null ? null : knownObject.toQNameURI());
   }
@@ -164,7 +165,7 @@ public class ChangeInfo {
    * @return The enum referencing the known object modifier of the change.
    */
   @XmlTransient
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public ChangeObjectModifier getKnownObjectModifier() {
     return getObjectModifier() == null ? null : ChangeObjectModifier.fromQNameURI(getObjectModifier());
   }
@@ -174,7 +175,7 @@ public class ChangeInfo {
    *
    * @param knownObject the change object.
    */
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownObjectModifier(ChangeObjectModifier knownObject) {
     setObjectModifier(knownObject == null ? null : knownObject.toQNameURI());
   }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/ChildAndParentsRelationship.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/ChildAndParentsRelationship.java
@@ -180,7 +180,7 @@ public class ChildAndParentsRelationship extends Subject {
    * @return The fact conclusions for the father.
    */
   @XmlElement (name="fatherFact")
-  @JsonProperty ("fatherFacts")
+  @JsonProperty ("fatherFacts") @org.codehaus.jackson.annotate.JsonProperty ("fatherFacts")
   public List<Fact> getFatherFacts() {
     return fatherFacts;
   }
@@ -190,7 +190,7 @@ public class ChildAndParentsRelationship extends Subject {
    *
    * @param facts The fact conclusions for the father.
    */
-  @JsonProperty("fatherFacts")
+  @JsonProperty("fatherFacts") @org.codehaus.jackson.annotate.JsonProperty("fatherFacts")
   public void setFatherFacts(List<Fact> facts) {
     this.fatherFacts = facts;
   }
@@ -226,7 +226,7 @@ public class ChildAndParentsRelationship extends Subject {
    * @return The fact conclusions for the mother.
    */
   @XmlElement (name="motherFact")
-  @JsonProperty ("motherFacts")
+  @JsonProperty ("motherFacts") @org.codehaus.jackson.annotate.JsonProperty ("motherFacts")
   public List<Fact> getMotherFacts() {
     return motherFacts;
   }
@@ -236,7 +236,7 @@ public class ChildAndParentsRelationship extends Subject {
    *
    * @param facts The fact conclusions for the mother.
    */
-  @JsonProperty("motherFacts")
+  @JsonProperty("motherFacts") @org.codehaus.jackson.annotate.JsonProperty("motherFacts")
   public void setMotherFacts(List<Fact> facts) {
     this.motherFacts = facts;
   }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/MatchInfo.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/MatchInfo.java
@@ -16,6 +16,7 @@
 package org.familysearch.platform.ct;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.webcohesion.enunciate.metadata.qname.XmlQNameEnumRef;
 import org.gedcomx.common.URI;
@@ -67,7 +68,7 @@ public class MatchInfo {
    * @deprecated Use get/setCollection
    */
   @XmlTransient
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public URI getSystem() {
     return getCollection();
   }
@@ -78,7 +79,7 @@ public class MatchInfo {
    * @param system The system in which this match was found.
    * @deprecated Use get/setCollection
    */
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setSystem(URI system) {
     setCollection(system);
   }
@@ -89,7 +90,7 @@ public class MatchInfo {
    * @return The enum referencing the known collection of this match.
    */
   @XmlTransient
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public MatchCollection getKnownCollection() {
     return getCollection() == null ? null : MatchCollection.fromQNameURI(getCollection());
   }
@@ -99,7 +100,7 @@ public class MatchInfo {
    *
    * @param knownCollection The enum referencing the known collection of this match.
    */
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownCollection(MatchCollection knownCollection) {
     setCollection(knownCollection == null ? null : knownCollection.toQNameURI());
   }
@@ -130,7 +131,7 @@ public class MatchInfo {
    * @return The enum referencing the known resolution of this match.
    */
   @XmlTransient
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public MatchStatus getKnownStatus() {
     return getStatus() == null ? null : MatchStatus.fromQNameURI(getStatus());
   }
@@ -140,7 +141,7 @@ public class MatchInfo {
    *
    * @param knownResolution The enum referencing the known resolution of this match.
    */
-  @com.fasterxml.jackson.annotation.JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownStatus(MatchStatus knownResolution) {
     setStatus(knownResolution == null ? null : knownResolution.toQNameURI());
   }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/Merge.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/Merge.java
@@ -43,7 +43,7 @@ public class Merge {
    * @return List of resources to remove from the survivor person.
    */
   @XmlElement (name="resourceToDelete")
-  @JsonProperty ("resourcesToDelete")
+  @JsonProperty ("resourcesToDelete") @org.codehaus.jackson.annotate.JsonProperty ("resourcesToDelete")
   public List<ResourceReference> getResourcesToDelete() {
     return resourcesToDelete;
   }
@@ -57,7 +57,7 @@ public class Merge {
    * @return List of resources to copy from the duplicate person to survivor person.
    */
   @XmlElement (name="resourceToCopy")
-  @JsonProperty ("resourcesToCopy")
+  @JsonProperty ("resourcesToCopy") @org.codehaus.jackson.annotate.JsonProperty ("resourcesToCopy")
   public List<ResourceReference> getResourcesToCopy() {
     return resourcesToCopy;
   }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/MergeAnalysis.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/MergeAnalysis.java
@@ -44,7 +44,7 @@ public class MergeAnalysis {
 
 
   @XmlElement (name="survivorResource")
-  @JsonProperty ("survivorResources")
+  @JsonProperty ("survivorResources") @org.codehaus.jackson.annotate.JsonProperty ("survivorResources")
   public List<ResourceReference> getSurvivorResources() {
     return survivorResources;
   }
@@ -54,7 +54,7 @@ public class MergeAnalysis {
   }
 
   @XmlElement (name="duplicateResource")
-  @JsonProperty ("duplicateResources")
+  @JsonProperty ("duplicateResources") @org.codehaus.jackson.annotate.JsonProperty ("duplicateResources")
   public List<ResourceReference> getDuplicateResources() {
     return duplicateResources;
   }
@@ -64,7 +64,7 @@ public class MergeAnalysis {
   }
 
   @XmlElement (name="conflictingResource")
-  @JsonProperty ("conflictingResources")
+  @JsonProperty ("conflictingResources") @org.codehaus.jackson.annotate.JsonProperty ("conflictingResources")
   public List<MergeConflict> getConflictingResources() {
     return conflictingResources;
   }
@@ -75,7 +75,7 @@ public class MergeAnalysis {
 
 
   @XmlElement (name="survivor")
-  @JsonProperty ("survivor")
+  @JsonProperty ("survivor") @org.codehaus.jackson.annotate.JsonProperty ("survivor")
   public ResourceReference getSurvivor() {
     return survivor;
   }
@@ -85,7 +85,7 @@ public class MergeAnalysis {
   }
 
   @XmlElement (name="duplicate")
-  @JsonProperty ("duplicate")
+  @JsonProperty ("duplicate") @org.codehaus.jackson.annotate.JsonProperty ("duplicate")
   public ResourceReference getDuplicate() {
     return duplicate;
   }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/MergeConflict.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/MergeConflict.java
@@ -45,7 +45,7 @@ public class MergeConflict {
   }
 
   @XmlElement (name="survivorResource")
-  @JsonProperty ("survivorResource")
+  @JsonProperty ("survivorResource") @org.codehaus.jackson.annotate.JsonProperty ("survivorResource")
   public ResourceReference getSurvivorResource() {
     return survivorResource;
   }
@@ -55,7 +55,7 @@ public class MergeConflict {
   }
 
   @XmlElement (name="duplicateResource")
-  @JsonProperty ("duplicateResource")
+  @JsonProperty ("duplicateResource") @org.codehaus.jackson.annotate.JsonProperty ("duplicateResource")
   public ResourceReference getDuplicateResource() {
     return duplicateResource;
   }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/NameFormInfo.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/ct/NameFormInfo.java
@@ -64,7 +64,7 @@ public class NameFormInfo {
    * @return The enum referencing the known resolution of this name form order.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public NameFormOrder getKnownOrder() {
     return getOrder() == null ? null : NameFormOrder.fromQNameURI(getOrder());
   }
@@ -74,7 +74,7 @@ public class NameFormInfo {
    *
    * @param nameFormOrder The enum referencing the known resolution of this name form order.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownOrder(NameFormOrder nameFormOrder) {
     setOrder(nameFormOrder == null ? null : nameFormOrder.toQNameURI());
   }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/discussions/Discussion.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/discussions/Discussion.java
@@ -217,7 +217,7 @@ public class Discussion extends HypermediaEnabledData {
    * @return The comments on this discussion.
    */
   @XmlElement ( name="comment" )
-  @JsonProperty ( "comments" )
+  @JsonProperty ( "comments" ) @org.codehaus.jackson.annotate.JsonProperty ( "comments" )
   public List<Comment> getComments() {
     return comments;
   }
@@ -227,7 +227,7 @@ public class Discussion extends HypermediaEnabledData {
    *
    * @param comments The comments on this discussion.
    */
-  @JsonProperty ( "comments" )
+  @JsonProperty ( "comments" ) @org.codehaus.jackson.annotate.JsonProperty ( "comments" )
   public void setComments(List<Comment> comments) {
     this.comments = comments;
   }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/reservations/Reservation.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/reservations/Reservation.java
@@ -72,7 +72,7 @@ public class Reservation extends Conclusion {
    * @return The enum referencing the known ordinance type, or {@link OrdinanceType#OTHER} if not known.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public OrdinanceType getKnownType() {
     return getType() == null ? null : OrdinanceType.fromQNameURI(getType());
   }
@@ -82,7 +82,7 @@ public class Reservation extends Conclusion {
    *
    * @param knownType The ordinance type.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(OrdinanceType knownType) {
     setType(knownType == null ? null : knownType.toQNameURI());
   }
@@ -145,7 +145,7 @@ public class Reservation extends Conclusion {
    * @return The enum referencing the known ordinance status, or {@link OrdinanceStatus#OTHER} if not known.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public OrdinanceStatus getKnownStatus() {
     return getStatus() == null ? null : OrdinanceStatus.fromQNameURI(getStatus());
   }
@@ -155,7 +155,7 @@ public class Reservation extends Conclusion {
    *
    * @param knownStatus The ordinance status.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownStatus(OrdinanceStatus knownStatus) {
     setStatus(knownStatus == null ? null : knownStatus.toQNameURI());
   }

--- a/gedcomx-atom/pom.xml
+++ b/gedcomx-atom/pom.xml
@@ -26,6 +26,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
       <version>${jersey.version}</version>

--- a/gedcomx-atom/src/main/java/org/gedcomx/atom/Content.java
+++ b/gedcomx-atom/src/main/java/org/gedcomx/atom/Content.java
@@ -43,7 +43,7 @@ public final class Content {
    * @return The type of the content.
    */
   @XmlAttribute
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public String getType() {
     return type;
   }
@@ -53,7 +53,7 @@ public final class Content {
    *
    * @param type The type of the content.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setType(String type) {
     this.type = type;
   }

--- a/gedcomx-atom/src/main/java/org/gedcomx/atom/Entry.java
+++ b/gedcomx-atom/src/main/java/org/gedcomx/atom/Entry.java
@@ -68,7 +68,7 @@ public class Entry extends ExtensibleElement implements SupportsLinks {
    * @return The author of the entry.
    */
   @XmlElement ( name = "author" )
-  @JsonProperty ( "authors" )
+  @JsonProperty ( "authors" ) @org.codehaus.jackson.annotate.JsonProperty ( "authors" )
   public List<Person> getAuthors() {
     return authors;
   }
@@ -78,7 +78,7 @@ public class Entry extends ExtensibleElement implements SupportsLinks {
    *
    * @param authors The author of the entry.
    */
-  @JsonProperty ( "authors" )
+  @JsonProperty ( "authors" ) @org.codehaus.jackson.annotate.JsonProperty ( "authors" )
   public void setAuthors(List<Person> authors) {
     this.authors = authors;
   }
@@ -89,7 +89,7 @@ public class Entry extends ExtensibleElement implements SupportsLinks {
    * @return information about a category associated with an entry.
    */
   @XmlElement ( name = "category" )
-  @JsonProperty ( "categories" )
+  @JsonProperty ( "categories" ) @org.codehaus.jackson.annotate.JsonProperty ( "categories" )
   public List<Category> getCategories() {
     return categories;
   }
@@ -99,7 +99,7 @@ public class Entry extends ExtensibleElement implements SupportsLinks {
    *
    * @param categories information about a category associated with an entry.
    */
-  @JsonProperty ( "categories" )
+  @JsonProperty ( "categories" ) @org.codehaus.jackson.annotate.JsonProperty ( "categories" )
   public void setCategories(List<Category> categories) {
     this.categories = categories;
   }
@@ -128,7 +128,7 @@ public class Entry extends ExtensibleElement implements SupportsLinks {
    * @return information about a category associated with the entry
    */
   @XmlElement ( name = "contributor" )
-  @JsonProperty ( "contributors" )
+  @JsonProperty ( "contributors" ) @org.codehaus.jackson.annotate.JsonProperty ( "contributors" )
   public List<Person> getContributors() {
     return contributors;
   }
@@ -138,7 +138,7 @@ public class Entry extends ExtensibleElement implements SupportsLinks {
    *
    * @param contributors information about a category associated with the entry
    */
-  @JsonProperty ( "contributors" )
+  @JsonProperty ( "contributors" ) @org.codehaus.jackson.annotate.JsonProperty ( "contributors" )
   public void setContributors(List<Person> contributors) {
     this.contributors = contributors;
   }
@@ -206,7 +206,7 @@ public class Entry extends ExtensibleElement implements SupportsLinks {
    * @return a reference from a entry to a Web resource.
    */
   @XmlElement ( name = "link" )
-  @JsonProperty ( "links" )
+  @JsonProperty ( "links" ) @org.codehaus.jackson.annotate.JsonProperty ( "links" )
   public List<Link> getLinks() {
     return links;
   }
@@ -216,7 +216,7 @@ public class Entry extends ExtensibleElement implements SupportsLinks {
    *
    * @param links a reference from a entry to a Web resource.
    */
-  @JsonProperty ( "links" )
+  @JsonProperty ( "links" ) @org.codehaus.jackson.annotate.JsonProperty ( "links" )
   public void setLinks(List<Link> links) {
     this.links = links;
   }
@@ -365,7 +365,7 @@ public class Entry extends ExtensibleElement implements SupportsLinks {
   }
 
   @XmlAnyAttribute
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public Map<QName, String> getExtensionAttributes() {
     return extensionAttributes;
   }

--- a/gedcomx-atom/src/main/java/org/gedcomx/atom/ExtensibleElement.java
+++ b/gedcomx-atom/src/main/java/org/gedcomx/atom/ExtensibleElement.java
@@ -42,7 +42,7 @@ public abstract class ExtensibleElement extends CommonAttributes implements Supp
    * @return Custom extension elements.
    */
   @XmlAnyElement (lax = true)
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public List<Object> getExtensionElements() {
     return extensionElements;
   }
@@ -52,7 +52,7 @@ public abstract class ExtensibleElement extends CommonAttributes implements Supp
    *
    * @param extensionElements Custom extension elements.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setExtensionElements(List<Object> extensionElements) {
     this.extensionElements = extensionElements;
   }
@@ -109,7 +109,7 @@ public abstract class ExtensibleElement extends CommonAttributes implements Supp
     return ext;
   }
 
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @XmlTransient
   @Override
   public Map<String, Object> getTransientProperties() {

--- a/gedcomx-atom/src/main/java/org/gedcomx/atom/Feed.java
+++ b/gedcomx-atom/src/main/java/org/gedcomx/atom/Feed.java
@@ -86,7 +86,7 @@ public class Feed extends ExtensibleElement implements SupportsLinks {
    * @return The author of the feed.
    */
   @XmlElement ( name = "author" )
-  @JsonProperty ( "authors" )
+  @JsonProperty ( "authors" ) @org.codehaus.jackson.annotate.JsonProperty ( "authors" )
   public List<Person> getAuthors() {
     return authors;
   }
@@ -96,7 +96,7 @@ public class Feed extends ExtensibleElement implements SupportsLinks {
    *
    * @param authors The author of the feed.
    */
-  @JsonProperty ( "authors" )
+  @JsonProperty ( "authors" ) @org.codehaus.jackson.annotate.JsonProperty ( "authors" )
   public void setAuthors(List<Person> authors) {
     this.authors = authors;
   }
@@ -107,7 +107,7 @@ public class Feed extends ExtensibleElement implements SupportsLinks {
    * @return information about a category associated with the feed
    */
   @XmlElement ( name = "contributor" )
-  @JsonProperty ( "contributors" )
+  @JsonProperty ( "contributors" ) @org.codehaus.jackson.annotate.JsonProperty ( "contributors" )
   public List<Person> getContributors() {
     return contributors;
   }
@@ -117,7 +117,7 @@ public class Feed extends ExtensibleElement implements SupportsLinks {
    *
    * @param contributors information about a category associated with the feed
    */
-  @JsonProperty ( "contributors" )
+  @JsonProperty ( "contributors" ) @org.codehaus.jackson.annotate.JsonProperty ( "contributors" )
   public void setContributors(List<Person> contributors) {
     this.contributors = contributors;
   }
@@ -222,7 +222,7 @@ public class Feed extends ExtensibleElement implements SupportsLinks {
    * @return a reference from a feed to a Web resource.
    */
   @XmlElement ( name = "link" )
-  @JsonProperty ( "links" )
+  @JsonProperty ( "links" ) @org.codehaus.jackson.annotate.JsonProperty ( "links" )
   public List<Link> getLinks() {
     return links;
   }
@@ -232,7 +232,7 @@ public class Feed extends ExtensibleElement implements SupportsLinks {
    *
    * @param links a reference from a feed to a Web resource.
    */
-  @JsonProperty ( "links" )
+  @JsonProperty ( "links" ) @org.codehaus.jackson.annotate.JsonProperty ( "links" )
   public void setLinks(List<Link> links) {
     this.links = links;
   }
@@ -405,7 +405,7 @@ public class Feed extends ExtensibleElement implements SupportsLinks {
    * @return The entries in the feed.
    */
   @XmlElement ( name = "entry" )
-  @JsonProperty ( "entries" )
+  @JsonProperty ( "entries" ) @org.codehaus.jackson.annotate.JsonProperty ( "entries" )
   public List<Entry> getEntries() {
     return entries;
   }
@@ -415,7 +415,7 @@ public class Feed extends ExtensibleElement implements SupportsLinks {
    *
    * @param entries The entries in the feed.
    */
-  @JsonProperty ( "entries" )
+  @JsonProperty ( "entries" ) @org.codehaus.jackson.annotate.JsonProperty ( "entries" )
   public void setEntries(List<Entry> entries) {
     this.entries = entries;
   }
@@ -426,7 +426,7 @@ public class Feed extends ExtensibleElement implements SupportsLinks {
    * @return The list of facets for the feed, used for convenience in browsing and filtering.
    */
   @XmlElement ( name = "facet" )
-  @JsonProperty ( "facets" )
+  @JsonProperty ( "facets" ) @org.codehaus.jackson.annotate.JsonProperty ( "facets" )
   public List<Field> getFacets() {
     return facets;
   }
@@ -436,7 +436,7 @@ public class Feed extends ExtensibleElement implements SupportsLinks {
    *
    * @param facets The list of facets for the feed, used for convenience in browsing and filtering.
    */
-  @JsonProperty ( "facets" )
+  @JsonProperty ( "facets" ) @org.codehaus.jackson.annotate.JsonProperty ( "facets" )
   public void setFacets(List<Field> facets) {
     this.facets = facets;
   }

--- a/gedcomx-atom/src/main/java/org/gedcomx/search/ResultConfidence.java
+++ b/gedcomx-atom/src/main/java/org/gedcomx/search/ResultConfidence.java
@@ -69,7 +69,7 @@ public enum ResultConfidence {
   @XmlEnumValue("5")
   five;
 
-  @JsonValue
+  @JsonValue @org.codehaus.jackson.annotate.JsonValue
   public Integer value() {
     switch(this) {
       case one:

--- a/gedcomx-model/pom.xml
+++ b/gedcomx-model/pom.xml
@@ -25,6 +25,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.gedcomx</groupId>
       <artifactId>gedcomx-date</artifactId>
       <version>${project.version}</version>

--- a/gedcomx-model/src/main/java/org/gedcomx/Gedcomx.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/Gedcomx.java
@@ -136,7 +136,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return A reference to a description of this data set.
    */
   @XmlAttribute ( name = "description" )
-  @JsonProperty ( "description" )
+  @JsonProperty ( "description" ) @org.codehaus.jackson.annotate.JsonProperty ( "description" )
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public URI getDescriptionRef() {
     return descriptionRef;
@@ -147,7 +147,7 @@ public class Gedcomx extends HypermediaEnabledData {
    *
    * @param descriptionRef A reference to a description of this data set.
    */
-  @JsonProperty ( "description" )
+  @JsonProperty ( "description" ) @org.codehaus.jackson.annotate.JsonProperty ( "description" )
   public void setDescriptionRef(URI descriptionRef) {
     this.descriptionRef = descriptionRef;
   }
@@ -197,7 +197,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The first person in the document.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public Person getPerson() {
     return this.persons != null && this.persons.size() > 0 ? this.persons.get(0) : null;
   }
@@ -208,7 +208,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The persons included in this genealogical data set.
    */
   @XmlElement (name="person")
-  @JsonProperty ("persons")
+  @JsonProperty ("persons") @org.codehaus.jackson.annotate.JsonProperty ("persons")
   public List<Person> getPersons() {
     return persons;
   }
@@ -218,7 +218,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * 
    * @param persons The persons included in this genealogical data set.
    */
-  @JsonProperty ("persons")
+  @JsonProperty ("persons") @org.codehaus.jackson.annotate.JsonProperty ("persons")
   public void setPersons(List<Person> persons) {
     this.persons = persons;
   }
@@ -252,7 +252,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The list of couple relationships in the document.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public List<Relationship> getCoupleRelationships() {
     ArrayList<Relationship> filtered = null;
     if (this.relationships != null) {
@@ -272,7 +272,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The list of parent-child relationships in the document.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public List<Relationship> getParentChildRelationships() {
     ArrayList<Relationship> filtered = null;
     if (this.relationships != null) {
@@ -353,7 +353,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The relationships included in this genealogical data set.
    */
   @XmlElement (name="relationship")
-  @JsonProperty ("relationships")
+  @JsonProperty ("relationships") @org.codehaus.jackson.annotate.JsonProperty ("relationships")
   public List<Relationship> getRelationships() {
     return relationships;
   }
@@ -363,7 +363,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * 
    * @param relationships The relationships included in this genealogical data set.
    */
-  @JsonProperty ("relationships")
+  @JsonProperty ("relationships") @org.codehaus.jackson.annotate.JsonProperty ("relationships")
   public void setRelationships(List<Relationship> relationships) {
     this.relationships = relationships;
   }
@@ -397,7 +397,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The first source description in the document.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public SourceDescription getSourceDescription() {
     return this.sourceDescriptions != null && this.sourceDescriptions.size() > 0 ? this.sourceDescriptions.get(0) : null;
   }
@@ -427,7 +427,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The descriptions of sources included in this genealogical data set.
    */
   @XmlElement (name="sourceDescription")
-  @JsonProperty ("sourceDescriptions")
+  @JsonProperty ("sourceDescriptions") @org.codehaus.jackson.annotate.JsonProperty ("sourceDescriptions")
   public List<SourceDescription> getSourceDescriptions() {
     return sourceDescriptions;
   }
@@ -437,7 +437,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * 
    * @param sourceDescriptions The descriptions of sources included in this genealogical data set.
    */
-  @JsonProperty ("sourceDescriptions")
+  @JsonProperty ("sourceDescriptions") @org.codehaus.jackson.annotate.JsonProperty ("sourceDescriptions")
   public void setSourceDescriptions(List<SourceDescription> sourceDescriptions) {
     this.sourceDescriptions = sourceDescriptions;
   }
@@ -471,7 +471,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The agents included in this genealogical data set.
    */
   @XmlElement (name="agent")
-  @JsonProperty ("agents")
+  @JsonProperty ("agents") @org.codehaus.jackson.annotate.JsonProperty ("agents")
   public List<Agent> getAgents() {
     return agents;
   }
@@ -481,7 +481,7 @@ public class Gedcomx extends HypermediaEnabledData {
    *
    * @param agents The agents included in this genealogical data set.
    */
-  @JsonProperty ("agents")
+  @JsonProperty ("agents") @org.codehaus.jackson.annotate.JsonProperty ("agents")
   public void setAgents(List<Agent> agents) {
     this.agents = agents;
   }
@@ -515,7 +515,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The events included in this genealogical data set.
    */
   @XmlElement (name="event")
-  @JsonProperty ("events")
+  @JsonProperty ("events") @org.codehaus.jackson.annotate.JsonProperty ("events")
   public List<Event> getEvents() {
     return events;
   }
@@ -525,7 +525,7 @@ public class Gedcomx extends HypermediaEnabledData {
    *
    * @param events The events included in this genealogical data set.
    */
-  @JsonProperty ("events")
+  @JsonProperty ("events") @org.codehaus.jackson.annotate.JsonProperty ("events")
   public void setEvents(List<Event> events) {
     this.events = events;
   }
@@ -559,7 +559,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The places included in this genealogical data set.
    */
   @XmlElement (name="place")
-  @JsonProperty ("places")
+  @JsonProperty ("places") @org.codehaus.jackson.annotate.JsonProperty ("places")
   public List<PlaceDescription> getPlaces() {
     return places;
   }
@@ -569,7 +569,7 @@ public class Gedcomx extends HypermediaEnabledData {
    *
    * @param places The places included in this genealogical data set.
    */
-  @JsonProperty ("places")
+  @JsonProperty ("places") @org.codehaus.jackson.annotate.JsonProperty ("places")
   public void setPlaces(List<PlaceDescription> places) {
     this.places = places;
   }
@@ -603,7 +603,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The documents included in this genealogical data set.
    */
   @XmlElement (name="document")
-  @JsonProperty ("documents")
+  @JsonProperty ("documents") @org.codehaus.jackson.annotate.JsonProperty ("documents")
   public List<Document> getDocuments() {
     return documents;
   }
@@ -613,7 +613,7 @@ public class Gedcomx extends HypermediaEnabledData {
    *
    * @param documents The documents included in this genealogical data set.
    */
-  @JsonProperty ("documents")
+  @JsonProperty ("documents") @org.codehaus.jackson.annotate.JsonProperty ("documents")
   public void setDocuments(List<Document> documents) {
     this.documents = documents;
   }
@@ -647,7 +647,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The collections included in this genealogical data set.
    */
   @XmlElement (name="collection")
-  @JsonProperty ("collections")
+  @JsonProperty ("collections") @org.codehaus.jackson.annotate.JsonProperty ("collections")
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<Collection> getCollections() {
     return collections;
@@ -658,7 +658,7 @@ public class Gedcomx extends HypermediaEnabledData {
    *
    * @param collections The collections included in this genealogical data set.
    */
-  @JsonProperty ("collections")
+  @JsonProperty ("collections") @org.codehaus.jackson.annotate.JsonProperty ("collections")
   public void setCollections(List<Collection> collections) {
     this.collections = collections;
   }
@@ -695,7 +695,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The extracted fields included in this genealogical data set.
    */
   @XmlElement (name="field")
-  @JsonProperty ("fields")
+  @JsonProperty ("fields") @org.codehaus.jackson.annotate.JsonProperty ("fields")
   @com.webcohesion.enunciate.metadata.Facet( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<Field> getFields() {
     return fields;
@@ -706,7 +706,7 @@ public class Gedcomx extends HypermediaEnabledData {
    *
    * @param fields The extracted fields included in this genealogical data set.
    */
-  @JsonProperty ("fields")
+  @JsonProperty ("fields") @org.codehaus.jackson.annotate.JsonProperty ("fields")
   public void setFields(List<Field> fields) {
     this.fields = fields;
   }
@@ -740,7 +740,7 @@ public class Gedcomx extends HypermediaEnabledData {
    * @return The record descriptors included in this genealogical data set.
    */
   @XmlElement (name="recordDescriptor")
-  @JsonProperty ("recordDescriptors")
+  @JsonProperty ("recordDescriptors") @org.codehaus.jackson.annotate.JsonProperty ("recordDescriptors")
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<RecordDescriptor> getRecordDescriptors() {
     return recordDescriptors;
@@ -751,7 +751,7 @@ public class Gedcomx extends HypermediaEnabledData {
    *
    * @param recordDescriptors The record descriptors included in this genealogical data set.
    */
-  @JsonProperty ("recordDescriptors")
+  @JsonProperty ("recordDescriptors") @org.codehaus.jackson.annotate.JsonProperty ("recordDescriptors")
   public void setRecordDescriptors(List<RecordDescriptor> recordDescriptors) {
     this.recordDescriptors = recordDescriptors;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/agent/Agent.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/agent/Agent.java
@@ -83,7 +83,7 @@ public class Agent extends HypermediaEnabledData {
    * @return The preferred name for this agent.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public TextValue getName() {
     return this.names == null || this.names.isEmpty() ? null : this.names.get(0);
   }
@@ -94,7 +94,7 @@ public class Agent extends HypermediaEnabledData {
    * @return The list of names for the agent.
    */
   @XmlElement (name="name")
-  @JsonProperty ("names")
+  @JsonProperty ("names") @org.codehaus.jackson.annotate.JsonProperty ("names")
   public List<TextValue> getNames() {
     return names;
   }
@@ -104,7 +104,7 @@ public class Agent extends HypermediaEnabledData {
    *
    * @param names The list of names for the agent.
    */
-  @JsonProperty ("names")
+  @JsonProperty ("names") @org.codehaus.jackson.annotate.JsonProperty ("names")
   public void setNames(List<TextValue> names) {
     this.names = names;
   }
@@ -149,7 +149,7 @@ public class Agent extends HypermediaEnabledData {
    * @return The list of identifiers for the agent.
    */
   @XmlElement (name="identifier")
-  @JsonProperty ("identifiers")
+  @JsonProperty ("identifiers") @org.codehaus.jackson.annotate.JsonProperty ("identifiers")
   public List<Identifier> getIdentifiers() {
     return identifiers;
   }
@@ -159,7 +159,7 @@ public class Agent extends HypermediaEnabledData {
    *
    * @param identifiers The list of identifiers of the agent.
    */
-  @JsonProperty ("identifiers")
+  @JsonProperty ("identifiers") @org.codehaus.jackson.annotate.JsonProperty ("identifiers")
   public void setIdentifiers(List<Identifier> identifiers) {
     this.identifiers = identifiers;
   }
@@ -270,7 +270,7 @@ public class Agent extends HypermediaEnabledData {
    * @return The accounts that belong to this person or organization.
    */
   @XmlElement(name = "account")
-  @JsonProperty ("accounts")
+  @JsonProperty ("accounts") @org.codehaus.jackson.annotate.JsonProperty ("accounts")
   public List<OnlineAccount> getAccounts() {
     return accounts;
   }
@@ -280,7 +280,7 @@ public class Agent extends HypermediaEnabledData {
    *
    * @param accounts The accounts that belong to this person or organization.
    */
-  @JsonProperty ("accounts")
+  @JsonProperty ("accounts") @org.codehaus.jackson.annotate.JsonProperty ("accounts")
   public void setAccounts(List<OnlineAccount> accounts) {
     this.accounts = accounts;
   }
@@ -314,7 +314,7 @@ public class Agent extends HypermediaEnabledData {
    * @return The emails that belong to this person or organization.
    */
   @XmlElement(name = "email")
-  @JsonProperty ("emails")
+  @JsonProperty ("emails") @org.codehaus.jackson.annotate.JsonProperty ("emails")
   public List<ResourceReference> getEmails() {
     return emails;
   }
@@ -324,7 +324,7 @@ public class Agent extends HypermediaEnabledData {
    *
    * @param emails The emails that belong to this person or organization.
    */
-  @JsonProperty ("emails")
+  @JsonProperty ("emails") @org.codehaus.jackson.annotate.JsonProperty ("emails")
   public void setEmails(List<ResourceReference> emails) {
     this.emails = emails;
   }
@@ -379,7 +379,7 @@ public class Agent extends HypermediaEnabledData {
    * @return The phones that belong to this person or organization.
    */
   @XmlElement(name = "phone")
-  @JsonProperty ("phones")
+  @JsonProperty ("phones") @org.codehaus.jackson.annotate.JsonProperty ("phones")
   public List<ResourceReference> getPhones() {
     return phones;
   }
@@ -389,7 +389,7 @@ public class Agent extends HypermediaEnabledData {
    *
    * @param phones The phones that belong to this person or organization.
    */
-  @JsonProperty ("phones")
+  @JsonProperty ("phones") @org.codehaus.jackson.annotate.JsonProperty ("phones")
   public void setPhones(List<ResourceReference> phones) {
     this.phones = phones;
   }
@@ -441,7 +441,7 @@ public class Agent extends HypermediaEnabledData {
    * @return The addresses that belong to this person or organization.
    */
   @XmlElement(name = "address")
-  @JsonProperty ("addresses")
+  @JsonProperty ("addresses") @org.codehaus.jackson.annotate.JsonProperty ("addresses")
   @SuppressWarnings("gedcomx:plural_xml_name")
   public List<Address> getAddresses() {
     return addresses;
@@ -452,7 +452,7 @@ public class Agent extends HypermediaEnabledData {
    *
    * @param addresses The addresses that belong to this person or organization.
    */
-  @JsonProperty ("addresses")
+  @JsonProperty ("addresses") @org.codehaus.jackson.annotate.JsonProperty ("addresses")
   public void setAddresses(List<Address> addresses) {
     this.addresses = addresses;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/common/ExtensibleData.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/ExtensibleData.java
@@ -70,7 +70,7 @@ public abstract class ExtensibleData implements SupportsExtensionElements, HasTr
    * @return Custom extension elements for a conclusion.
    */
   @XmlAnyElement (lax = true)
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public List<Object> getExtensionElements() {
     return extensionElements;
   }
@@ -80,7 +80,7 @@ public abstract class ExtensibleData implements SupportsExtensionElements, HasTr
    *
    * @param extensionElements Custom extension elements for a conclusion.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setExtensionElements(List<Object> extensionElements) {
     this.extensionElements = extensionElements;
   }
@@ -224,7 +224,7 @@ public abstract class ExtensibleData implements SupportsExtensionElements, HasTr
    *
    * @return the transient properties.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @XmlTransient
   @Override
   public Map<String, Object> getTransientProperties() {

--- a/gedcomx-model/src/main/java/org/gedcomx/common/Qualifier.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/Qualifier.java
@@ -64,7 +64,7 @@ public final class Qualifier {
    * @return The name of the qualifier.
    */
   @XmlAttribute
-  @JsonProperty ( "name" )
+  @JsonProperty ( "name" ) @org.codehaus.jackson.annotate.JsonProperty ( "name" )
   public URI getName() {
     return name;
   }
@@ -74,7 +74,7 @@ public final class Qualifier {
    *
    * @param name The name of the qualifier.
    */
-  @JsonProperty ( "name" )
+  @JsonProperty ( "name" ) @org.codehaus.jackson.annotate.JsonProperty ( "name" )
   public void setName(URI name) {
     this.name = name;
   }
@@ -96,7 +96,7 @@ public final class Qualifier {
    * @param element The element.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setName(ControlledVocabulary element) {
     this.name = element == null ? null : element.toQNameURI();
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/common/URI.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/URI.java
@@ -57,7 +57,7 @@ public final class URI {
   }
 
   @Override
-  @JsonValue
+  @JsonValue @org.codehaus.jackson.annotate.JsonValue
   public String toString() {
     return this.value;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Conclusion.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Conclusion.java
@@ -154,7 +154,7 @@ public abstract class Conclusion extends HypermediaEnabledData implements Attrib
    * @return The value of a the known confidence level, or {@link org.gedcomx.types.ConfidenceLevel#OTHER} if not known.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public ConfidenceLevel getKnownConfidenceLevel() {
     return getConfidence() == null ? null : ConfidenceLevel.fromQNameURI(getConfidence());
   }
@@ -164,7 +164,7 @@ public abstract class Conclusion extends HypermediaEnabledData implements Attrib
    *
    * @param level The known level.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownConfidenceLevel(ConfidenceLevel level) {
     setConfidence(level == null ? null : level.toQNameURI());
   }
@@ -175,7 +175,7 @@ public abstract class Conclusion extends HypermediaEnabledData implements Attrib
    * @return The source references for a conclusion.
    */
   @XmlElement (name="source")
-  @JsonProperty ("sources")
+  @JsonProperty ("sources") @org.codehaus.jackson.annotate.JsonProperty ("sources")
   public List<SourceReference> getSources() {
     return sources;
   }
@@ -185,7 +185,7 @@ public abstract class Conclusion extends HypermediaEnabledData implements Attrib
    *
    * @param sourceReferences The source references for a conclusion.
    */
-  @JsonProperty("sources")
+  @JsonProperty("sources") @org.codehaus.jackson.annotate.JsonProperty("sources")
   public void setSources(List<SourceReference> sourceReferences) {
     this.sources = sourceReferences;
   }
@@ -231,7 +231,7 @@ public abstract class Conclusion extends HypermediaEnabledData implements Attrib
    * @return Notes about a person.
    */
   @XmlElement (name = "note")
-  @JsonProperty ("notes")
+  @JsonProperty ("notes") @org.codehaus.jackson.annotate.JsonProperty ("notes")
   public List<Note> getNotes() {
     return notes;
   }
@@ -241,7 +241,7 @@ public abstract class Conclusion extends HypermediaEnabledData implements Attrib
    *
    * @param notes Notes about a person.
    */
-  @JsonProperty ("notes")
+  @JsonProperty ("notes") @org.codehaus.jackson.annotate.JsonProperty ("notes")
   public void setNotes(List<Note> notes) {
     this.notes = notes;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Date.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Date.java
@@ -110,7 +110,7 @@ public class Date extends ExtensibleData implements HasFields {
    * @param formal The formal value.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setFormalDate(GedcomxDate formal) {
     if (formal != null) {
       setFormal(formal.toFormalString());
@@ -146,7 +146,7 @@ public class Date extends ExtensibleData implements HasFields {
    * are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.
    */
   @XmlElement ( name = "normalized" )
-  @JsonProperty ("normalized")
+  @JsonProperty ("normalized") @org.codehaus.jackson.annotate.JsonProperty ("normalized")
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RS )
   public List<TextValue> getNormalizedExtensions() {
     return normalized;
@@ -159,7 +159,7 @@ public class Date extends ExtensibleData implements HasFields {
    * @param normalized The list of normalized values for the date, provided for display purposes by the application. Normalized values are
    * not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.
    */
-  @JsonProperty ("normalized")
+  @JsonProperty ("normalized") @org.codehaus.jackson.annotate.JsonProperty ("normalized")
   public void setNormalizedExtensions(List<TextValue> normalized) {
     this.normalized = normalized;
   }
@@ -184,7 +184,7 @@ public class Date extends ExtensibleData implements HasFields {
    * @return The references to the record fields being used as evidence.
    */
   @XmlElement( name = "field" )
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<Field> getFields() {
     return fields;
@@ -195,7 +195,7 @@ public class Date extends ExtensibleData implements HasFields {
    *
    * @param fields - List of fields
    */
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   public void setFields(List<Field> fields) {
     this.fields = fields;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/DisplayProperties.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/DisplayProperties.java
@@ -387,7 +387,7 @@ public class DisplayProperties extends ExtensibleData {
    * @return The family views where this person is a parent.
    */
   @XmlElement(name="familyAsParent")
-  @JsonProperty("familiesAsParent")
+  @JsonProperty("familiesAsParent") @org.codehaus.jackson.annotate.JsonProperty("familiesAsParent")
   public List<FamilyView> getFamiliesAsParent() {
     return familiesAsParent;
   }
@@ -397,7 +397,7 @@ public class DisplayProperties extends ExtensibleData {
    *
    * @param familiesAsParent The families where this person is a parent
    */
-  @JsonProperty ("familiesAsParent")
+  @JsonProperty ("familiesAsParent") @org.codehaus.jackson.annotate.JsonProperty ("familiesAsParent")
   public void setFamiliesAsParent(List<FamilyView> familiesAsParent) {
     this.familiesAsParent = familiesAsParent;
   }
@@ -422,7 +422,7 @@ public class DisplayProperties extends ExtensibleData {
    * @return The family views where this person is a child
    */
   @XmlElement(name="familyAsChild")
-  @JsonProperty("familiesAsChild")
+  @JsonProperty("familiesAsChild") @org.codehaus.jackson.annotate.JsonProperty("familiesAsChild")
   public List<FamilyView> getFamiliesAsChild() {
     return familiesAsChild;
   }
@@ -432,7 +432,7 @@ public class DisplayProperties extends ExtensibleData {
    *
    * @param familiesAsChild The families where this person is a child 
    */
-  @JsonProperty ("familiesAsChild")
+  @JsonProperty ("familiesAsChild") @org.codehaus.jackson.annotate.JsonProperty ("familiesAsChild")
   public void setFamiliesAsChild(List<FamilyView> familiesAsChild) {
     this.familiesAsChild = familiesAsChild;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Document.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Document.java
@@ -205,7 +205,7 @@ public class Document extends Conclusion implements HasText, Attributable {
    * @return Whether the text of the document is to be interpreted as plain text (as opposed to XHTML).
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public boolean isPlainText() {
     return this.textType == null || TEXT_TYPE_PLAIN.equals(this.textType);
   }
@@ -216,7 +216,7 @@ public class Document extends Conclusion implements HasText, Attributable {
    * @return Whether the text of the document is to be interpreted as XHTML text (as opposed to plain text).
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public boolean isXhtmlText() {
     return TEXT_TYPE_XHTML.equals(this.textType);
   }
@@ -257,7 +257,7 @@ public class Document extends Conclusion implements HasText, Attributable {
    * @return The enum referencing the known type of the document, or {@link org.gedcomx.types.DocumentType#OTHER} if not known.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public org.gedcomx.types.DocumentType getKnownType() {
     return getType() == null ? null : DocumentType.fromQNameURI(getType());
   }
@@ -267,7 +267,7 @@ public class Document extends Conclusion implements HasText, Attributable {
    *
    * @param knownType the document type.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(org.gedcomx.types.DocumentType knownType) {
     setType(knownType == null ? null : knownType.toQNameURI());
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Event.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Event.java
@@ -236,7 +236,7 @@ public class Event extends Subject implements HasDateAndPlace {
    * @return The enum referencing the known type of the event, or {@link org.gedcomx.types.EventType#OTHER} if not known.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public org.gedcomx.types.EventType getKnownType() {
     return getType() == null ? null : EventType.fromQNameURI(getType());
   }
@@ -246,7 +246,7 @@ public class Event extends Subject implements HasDateAndPlace {
    *
    * @param knownType the event type.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(org.gedcomx.types.EventType knownType) {
     setType(knownType == null ? null : knownType.toQNameURI());
   }
@@ -319,7 +319,7 @@ public class Event extends Subject implements HasDateAndPlace {
    * @return The roles played in this event.
    */
   @XmlElement (name="role")
-  @JsonProperty ("roles")
+  @JsonProperty ("roles") @org.codehaus.jackson.annotate.JsonProperty ("roles")
   public List<EventRole> getRoles() {
     return roles;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/EventRole.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/EventRole.java
@@ -215,7 +215,7 @@ public class EventRole extends Conclusion {
    * @return The enum referencing the known role type, or {@link org.gedcomx.types.EventRoleType#OTHER} if not known.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public EventRoleType getKnownType() {
     return getType() == null ? null : EventRoleType.fromQNameURI(getType());
   }
@@ -225,7 +225,7 @@ public class EventRole extends Conclusion {
    *
    * @param knownType The role type.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(EventRoleType knownType) {
     setType(knownType == null ? null : knownType.toQNameURI());
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Fact.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Fact.java
@@ -234,7 +234,7 @@ public class Fact extends Conclusion implements HasDateAndPlace, HasFields {
    * @return The enum referencing the known type of the fact, or {@link org.gedcomx.types.FactType#OTHER} if not known.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public org.gedcomx.types.FactType getKnownType() {
     return getType() == null ? null : FactType.fromQNameURI(getType());
   }
@@ -244,7 +244,7 @@ public class Fact extends Conclusion implements HasDateAndPlace, HasFields {
    *
    * @param knownType the fact type.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(org.gedcomx.types.FactType knownType) {
     setType(knownType == null ? null : knownType.toQNameURI());
   }
@@ -375,7 +375,7 @@ public class Fact extends Conclusion implements HasDateAndPlace, HasFields {
    * @return The qualifiers associated with this fact.
    */
   @XmlElement ( name = "qualifier" )
-  @JsonProperty ( "qualifiers" )
+  @JsonProperty ( "qualifiers" ) @org.codehaus.jackson.annotate.JsonProperty ( "qualifiers" )
   @Facet ( GedcomxConstants.FACET_FS_FT_UNSUPPORTED )
   public List<Qualifier> getQualifiers() {
     return qualifiers;
@@ -386,7 +386,7 @@ public class Fact extends Conclusion implements HasDateAndPlace, HasFields {
    *
    * @param qualifiers qualifiers to associate with this fact.
    */
-  @JsonProperty ( "qualifiers" )
+  @JsonProperty ( "qualifiers" ) @org.codehaus.jackson.annotate.JsonProperty ( "qualifiers" )
   public void setQualifiers(List<Qualifier> qualifiers) {
     this.qualifiers = qualifiers;
   }
@@ -420,7 +420,7 @@ public class Fact extends Conclusion implements HasDateAndPlace, HasFields {
    * @return The references to the record fields being used as evidence.
    */
   @XmlElement ( name = "field" )
-  @JsonProperty ( "fields" )
+  @JsonProperty ( "fields" ) @org.codehaus.jackson.annotate.JsonProperty ( "fields" )
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<Field> getFields() {
     return fields;
@@ -431,7 +431,7 @@ public class Fact extends Conclusion implements HasDateAndPlace, HasFields {
    *
    * @param fields - List of fields
    */
-  @JsonProperty ( "fields" )
+  @JsonProperty ( "fields" ) @org.codehaus.jackson.annotate.JsonProperty ( "fields" )
   public void setFields(List<Field> fields) {
     this.fields = fields;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/FamilyView.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/FamilyView.java
@@ -120,7 +120,7 @@ public class FamilyView extends HypermediaEnabledData {
    * @return A list of references to the children of this family.
    */
   @XmlElement(name="child")
-  @JsonProperty("children")
+  @JsonProperty("children") @org.codehaus.jackson.annotate.JsonProperty("children")
   public List<ResourceReference> getChildren() {
     return children;
   }
@@ -130,7 +130,7 @@ public class FamilyView extends HypermediaEnabledData {
    *
    * @param children A list of references to the children of this family.
    */
-  @JsonProperty("children")
+  @JsonProperty("children") @org.codehaus.jackson.annotate.JsonProperty("children")
   public void setChildren(List<ResourceReference> children) {
     this.children = children;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Gender.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Gender.java
@@ -191,7 +191,7 @@ public class Gender extends Conclusion implements HasFields {
    * @return The type of the gender.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public GenderType getKnownType() {
     return getType() == null ? null : GenderType.fromQNameURI(getType());
   }
@@ -201,7 +201,7 @@ public class Gender extends Conclusion implements HasFields {
    *
    * @param type The type of the gender.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(GenderType type) {
     setType(type == null ? null : type.toQNameURI());
   }
@@ -212,7 +212,7 @@ public class Gender extends Conclusion implements HasFields {
    * @return The references to the record fields being used as evidence.
    */
   @XmlElement( name = "field" )
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<Field> getFields() {
     return fields;
@@ -223,7 +223,7 @@ public class Gender extends Conclusion implements HasFields {
    *
    * @param fields - List of fields
    */
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   public void setFields(List<Field> fields) {
     this.fields = fields;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Identifier.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Identifier.java
@@ -64,7 +64,7 @@ public final class Identifier implements HasJsonKey {
    * @return The id value.
    */
   @XmlValue
-  @JsonValue
+  @JsonValue @org.codehaus.jackson.annotate.JsonValue
   public URI getValue() {
     return value;
   }
@@ -74,7 +74,7 @@ public final class Identifier implements HasJsonKey {
    *
    * @param value The id value.
    */
-  @JsonValue
+  @JsonValue @org.codehaus.jackson.annotate.JsonValue
   public void setValue(URI value) {
     this.value = value;
   }
@@ -96,7 +96,7 @@ public final class Identifier implements HasJsonKey {
    * @return The type of the id.
    */
   @XmlAttribute
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @XmlQNameEnumRef (IdentifierType.class)
   public URI getType() {
     return type;
@@ -107,7 +107,7 @@ public final class Identifier implements HasJsonKey {
    *
    * @param type The type of the id.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setType(URI type) {
     this.type = type;
   }
@@ -149,7 +149,7 @@ public final class Identifier implements HasJsonKey {
    * @return The enum referencing a known identifier type, or {@link org.gedcomx.types.IdentifierType#OTHER} if not known.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public IdentifierType getKnownType() {
     return getType() == null ? null : IdentifierType.fromQNameURI(getType());
   }
@@ -159,26 +159,26 @@ public final class Identifier implements HasJsonKey {
    *
    * @param knownType The known identifier type.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(IdentifierType knownType) {
     setType(knownType == null ? null : knownType.toQNameURI());
   }
 
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @Override
   public boolean isHasUniqueKey() {
     return this.hasUniqueKey;
   }
 
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @Override
   public String getJsonKey() {
     return this.type == null ? null : this.type.toString();
   }
 
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @Override
   public void setJsonKey(String jsonKey) {
     this.type = new URI(jsonKey);

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Name.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Name.java
@@ -186,7 +186,7 @@ public class Name extends Conclusion {
    * @return The enum referencing the known name type, or {@link org.gedcomx.types.NameType#OTHER} if not known.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public NameType getKnownType() {
     return getType() == null ? null : NameType.fromQNameURI(getType());
   }
@@ -196,7 +196,7 @@ public class Name extends Conclusion {
    *
    * @param knownType The known type.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(NameType knownType) {
     setType(knownType == null ? null : knownType.toQNameURI());
   }
@@ -236,7 +236,7 @@ public class Name extends Conclusion {
    * @return Alternate forms of the name, such as the romanized form of a non-latin name.
    */
   @XmlElement (name = "nameForm")
-  @JsonProperty ("nameForms")
+  @JsonProperty ("nameForms") @org.codehaus.jackson.annotate.JsonProperty ("nameForms")
   public List<NameForm> getNameForms() {
     return nameForms;
   }
@@ -246,7 +246,7 @@ public class Name extends Conclusion {
    *
    * @return The first name form of this name.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @XmlTransient
   public NameForm getNameForm() {
     return this.nameForms != null && this.nameForms.size() > 0 ? this.nameForms.get(0) : null;
@@ -257,7 +257,7 @@ public class Name extends Conclusion {
    *
    * @param nameForms Alternate forms of the name, such as the romanized form of a non-latin name.
    */
-  @JsonProperty ("nameForms")
+  @JsonProperty ("nameForms") @org.codehaus.jackson.annotate.JsonProperty ("nameForms")
   public void setNameForms(List<NameForm> nameForms) {
     this.nameForms = nameForms;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/NameForm.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/NameForm.java
@@ -131,7 +131,7 @@ public class NameForm extends ExtensibleData implements HasFields {
    * @return The different parts of the name form.
    */
   @XmlElement (name = "part")
-  @JsonProperty ("parts")
+  @JsonProperty ("parts") @org.codehaus.jackson.annotate.JsonProperty ("parts")
   public List<NamePart> getParts() {
     return parts;
   }
@@ -141,7 +141,7 @@ public class NameForm extends ExtensibleData implements HasFields {
    *
    * @param parts The different parts of the name form.
    */
-  @JsonProperty ("parts")
+  @JsonProperty ("parts") @org.codehaus.jackson.annotate.JsonProperty ("parts")
   public void setParts(List<NamePart> parts) {
     this.parts = parts;
   }
@@ -190,7 +190,7 @@ public class NameForm extends ExtensibleData implements HasFields {
    * @return The references to the record fields being used as evidence.
    */
   @XmlElement( name = "field" )
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<Field> getFields() {
     return fields;
@@ -201,7 +201,7 @@ public class NameForm extends ExtensibleData implements HasFields {
    *
    * @param fields - List of fields
    */
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   public void setFields(List<Field> fields) {
     this.fields = fields;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/NamePart.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/NamePart.java
@@ -120,7 +120,7 @@ public final class NamePart extends ExtensibleData implements HasFields {
    * @return The enum referencing the known name part type, or {@link org.gedcomx.types.NamePartType#OTHER} if not known.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public NamePartType getKnownType() {
     return getType() == null ? null : NamePartType.fromQNameURI(getType());
   }
@@ -130,7 +130,7 @@ public final class NamePart extends ExtensibleData implements HasFields {
    *
    * @param knownType The name part type.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(NamePartType knownType) {
     setType(knownType == null ? null : knownType.toQNameURI());
   }
@@ -171,7 +171,7 @@ public final class NamePart extends ExtensibleData implements HasFields {
    * @return The qualifiers associated with this name part.
    */
   @XmlElement (name = "qualifier")
-  @JsonProperty ("qualifiers")
+  @JsonProperty ("qualifiers") @org.codehaus.jackson.annotate.JsonProperty ("qualifiers")
   @Facet ( GedcomxConstants.FACET_FS_FT_UNSUPPORTED )
   public List<Qualifier> getQualifiers() {
     return qualifiers;
@@ -181,7 +181,7 @@ public final class NamePart extends ExtensibleData implements HasFields {
    * Set the qualifiers associated with this name part.
    * @param qualifiers qualifiers to associate with this name part
    */
-  @JsonProperty ("qualifiers")
+  @JsonProperty ("qualifiers") @org.codehaus.jackson.annotate.JsonProperty ("qualifiers")
   public void setQualifiers(List<Qualifier> qualifiers) {
     this.qualifiers = qualifiers;
   }
@@ -217,7 +217,7 @@ public final class NamePart extends ExtensibleData implements HasFields {
    * @return The references to the record fields being used as evidence.
    */
   @XmlElement( name = "field" )
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<Field> getFields() {
     return fields;
@@ -228,7 +228,7 @@ public final class NamePart extends ExtensibleData implements HasFields {
    *
    * @param fields - List of fields
    */
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   public void setFields(List<Field> fields) {
     this.fields = fields;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Person.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Person.java
@@ -157,7 +157,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    * @return References to the persona being referenced.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public List<EvidenceReference> getPersonaReferences() {
     return getEvidence();
   }
@@ -167,7 +167,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    *
    * @param refs References to the persona being referenced.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setPersonaReferences(List<EvidenceReference> refs) {
     setEvidence(refs);
   }
@@ -336,7 +336,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    * @return The name conclusions for the person.
    */
   @XmlElement(name="name")
-  @JsonProperty("names")
+  @JsonProperty("names") @org.codehaus.jackson.annotate.JsonProperty("names")
   public List<Name> getNames() {
     return names;
   }
@@ -347,7 +347,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    * @return The first name of this person.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public Name getName() {
     return this.names != null && this.names.size() > 0 ? this.names.get(0) : null;
   }
@@ -358,7 +358,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    * @param type The type.
    * @return the first name in the name list of the specified type, or null if none.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public Name getFirstNameOfType(NameType type) {
     if (this.names == null) {
       return null;
@@ -379,7 +379,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    * @return the preferred name of the person or first name if there is no preferred name.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public Name getPreferredName() {
     if(this.names == null || this.names.size() <= 0) {
       return null;
@@ -401,7 +401,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    *
    * @param names The name conclusions for the person.
    */
-  @JsonProperty("names")
+  @JsonProperty("names") @org.codehaus.jackson.annotate.JsonProperty("names")
   public void setNames(List<Name> names) {
     this.names = names;
   }
@@ -446,7 +446,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    * @return The fact conclusions for the person.
    */
   @XmlElement(name="fact")
-  @JsonProperty("facts")
+  @JsonProperty("facts") @org.codehaus.jackson.annotate.JsonProperty("facts")
   public List<Fact> getFacts() {
     return facts;
   }
@@ -457,7 +457,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    * @param type The type.
    * @return the first fact in the fact list of the specified type, or null if none.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public Fact getFirstFactOfType(FactType type) {
     if (this.facts == null) {
       return null;
@@ -478,7 +478,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    * @param factType The type of facts to return.
    * @return The fact conclusions that match the factType. An empty list will be returned if no facts are found.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public List<Fact> getFacts(FactType factType) {
     ArrayList<Fact> factsToReturn = new ArrayList<Fact>();
     if (facts != null && factType != null) {
@@ -496,7 +496,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    *
    * @param facts The fact conclusions for the person.
    */
-  @JsonProperty("facts")
+  @JsonProperty("facts") @org.codehaus.jackson.annotate.JsonProperty("facts")
   public void setFacts(List<Fact> facts) {
     this.facts = facts;
   }
@@ -532,7 +532,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    * @return Display properties for the person. Display properties are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.
    */
   @XmlElement(name = "display")
-  @JsonProperty("display")
+  @JsonProperty("display") @org.codehaus.jackson.annotate.JsonProperty("display")
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RS )
   public DisplayProperties getDisplayExtension() {
     return display;
@@ -543,7 +543,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    *
    * @param display Display properties for the person. Display properties are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.
    */
-  @JsonProperty("display")
+  @JsonProperty("display") @org.codehaus.jackson.annotate.JsonProperty("display")
   public void setDisplayExtension(DisplayProperties display) {
     this.display = display;
   }
@@ -593,7 +593,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    * @return The references to the record fields being used as evidence.
    */
   @XmlElement( name = "field" )
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<Field> getFields() {
     return fields;
@@ -604,7 +604,7 @@ public class Person extends Subject implements HasFacts, HasFields {
    *
    * @param fields - List of fields
    */
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   public void setFields(List<Field> fields) {
     this.fields = fields;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDescription.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDescription.java
@@ -170,7 +170,7 @@ public class PlaceDescription extends Subject {
    * @return An ordered list of standardized (or normalized), fully-qualified (in terms of what is known of the applicable jurisdictional hierarchy) names for this place that are applicable to this description of this place.
    */
   @XmlElement (name = "name")
-  @JsonProperty ("names")
+  @JsonProperty ("names") @org.codehaus.jackson.annotate.JsonProperty ("names")
   public List<TextValue> getNames() {
     return names;
   }
@@ -184,7 +184,7 @@ public class PlaceDescription extends Subject {
    *
    * @param names An ordered list of standardized (or normalized), fully-qualified (in terms of what is known of the applicable jurisdictional hierarchy) names for this place that are applicable to this description of this place.
    */
-  @JsonProperty ("names")
+  @JsonProperty ("names") @org.codehaus.jackson.annotate.JsonProperty ("names")
   public void setNames(List<TextValue> names) {
     this.names = names;
   }
@@ -437,7 +437,7 @@ public class PlaceDescription extends Subject {
    * @return Display properties for the place. Display properties are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.
    */
   @XmlElement(name = "display")
-  @JsonProperty("display")
+  @JsonProperty("display") @org.codehaus.jackson.annotate.JsonProperty("display")
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RS )
   public PlaceDisplayProperties getDisplayExtension() {
     return display;
@@ -448,7 +448,7 @@ public class PlaceDescription extends Subject {
    *
    * @param display Display properties for the place. Display properties are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.
    */
-  @JsonProperty("display")
+  @JsonProperty("display") @org.codehaus.jackson.annotate.JsonProperty("display")
   public void setDisplayExtension(PlaceDisplayProperties display) {
     this.display = display;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceReference.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceReference.java
@@ -81,7 +81,7 @@ public class PlaceReference extends ExtensibleData implements HasFields {
    * @return A reference to a description of the place being referenced.
    */
   @XmlAttribute ( name = "description" )
-  @JsonProperty ( "description" )
+  @JsonProperty ( "description" ) @org.codehaus.jackson.annotate.JsonProperty ( "description" )
   @RDFRange (PlaceDescription.class)
   public URI getDescriptionRef() {
     return descriptionRef;
@@ -92,7 +92,7 @@ public class PlaceReference extends ExtensibleData implements HasFields {
    *
    * @param descriptionRef A reference to a description of the place being referenced.
    */
-  @JsonProperty ( "description" )
+  @JsonProperty ( "description" ) @org.codehaus.jackson.annotate.JsonProperty ( "description" )
   public void setDescriptionRef(URI descriptionRef) {
     this.descriptionRef = descriptionRef;
   }
@@ -127,7 +127,7 @@ public class PlaceReference extends ExtensibleData implements HasFields {
    * are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.
    */
   @XmlElement ( name = "normalized" )
-  @JsonProperty ("normalized")
+  @JsonProperty ("normalized") @org.codehaus.jackson.annotate.JsonProperty ("normalized")
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RS )
   public List<TextValue> getNormalizedExtensions() {
     return normalized;
@@ -140,7 +140,7 @@ public class PlaceReference extends ExtensibleData implements HasFields {
    * @param normalized The list of normalized values for the place, provided for display purposes by the application. Normalized values are
    * not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.
    */
-  @JsonProperty ("normalized")
+  @JsonProperty ("normalized") @org.codehaus.jackson.annotate.JsonProperty ("normalized")
   public void setNormalizedExtensions(List<TextValue> normalized) {
     this.normalized = normalized;
   }
@@ -176,7 +176,7 @@ public class PlaceReference extends ExtensibleData implements HasFields {
    * @return The references to the record fields being used as evidence.
    */
   @XmlElement( name = "field" )
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<Field> getFields() {
     return fields;
@@ -187,7 +187,7 @@ public class PlaceReference extends ExtensibleData implements HasFields {
    *
    * @param fields - List of fields
    */
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   public void setFields(List<Field> fields) {
     this.fields = fields;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Relationship.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Relationship.java
@@ -213,7 +213,7 @@ public class Relationship extends Subject implements HasFacts, HasFields {
    * @return The enum referencing the known type of the relationship, or {@link org.gedcomx.types.RelationshipType#OTHER} if not known.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public RelationshipType getKnownType() {
     return getType() == null ? null : RelationshipType.fromQNameURI(getType());
   }
@@ -223,7 +223,7 @@ public class Relationship extends Subject implements HasFacts, HasFields {
    *
    * @param type The relationship type.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(RelationshipType type) {
     setType(type == null ? null : type.toQNameURI());
   }
@@ -340,7 +340,7 @@ public class Relationship extends Subject implements HasFacts, HasFields {
    * @return The fact conclusions for the relationship.
    */
   @XmlElement(name="fact")
-  @JsonProperty("facts")
+  @JsonProperty("facts") @org.codehaus.jackson.annotate.JsonProperty("facts")
   public List<Fact> getFacts() {
     return facts;
   }
@@ -350,7 +350,7 @@ public class Relationship extends Subject implements HasFacts, HasFields {
    *
    * @param facts The fact conclusions for the relationship.
    */
-  @JsonProperty("facts")
+  @JsonProperty("facts") @org.codehaus.jackson.annotate.JsonProperty("facts")
   public void setFacts(List<Fact> facts) {
     this.facts = facts;
   }
@@ -385,7 +385,7 @@ public class Relationship extends Subject implements HasFacts, HasFields {
    * @return The references to the record fields being used as evidence.
    */
   @XmlElement( name = "field" )
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<Field> getFields() {
     return fields;
@@ -396,7 +396,7 @@ public class Relationship extends Subject implements HasFacts, HasFields {
    *
    * @param fields - List of fields
    */
-  @JsonProperty( "fields" )
+  @JsonProperty( "fields" ) @org.codehaus.jackson.annotate.JsonProperty( "fields" )
   public void setFields(List<Field> fields) {
     this.fields = fields;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Subject.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Subject.java
@@ -165,7 +165,7 @@ public abstract class Subject extends Conclusion implements Attributable {
    * @return The long-term, persistent identifier for this subject.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public URI getPersistentId() {
     URI identifier = null;
     if (this.identifiers != null) {
@@ -184,7 +184,7 @@ public abstract class Subject extends Conclusion implements Attributable {
    *
    * @param persistentId A long-term, persistent, globally unique identifier for this subject.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setPersistentId(URI persistentId) {
     if (this.identifiers == null) {
       this.identifiers = new ArrayList<Identifier>();
@@ -210,7 +210,7 @@ public abstract class Subject extends Conclusion implements Attributable {
    * @return The list of identifiers for the subject.
    */
   @XmlElement (name="identifier")
-  @JsonProperty ("identifiers")
+  @JsonProperty ("identifiers") @org.codehaus.jackson.annotate.JsonProperty ("identifiers")
   public List<Identifier> getIdentifiers() {
     return identifiers;
   }
@@ -220,7 +220,7 @@ public abstract class Subject extends Conclusion implements Attributable {
    *
    * @param identifiers The list of identifiers of the subject.
    */
-  @JsonProperty ("identifiers")
+  @JsonProperty ("identifiers") @org.codehaus.jackson.annotate.JsonProperty ("identifiers")
   public void setIdentifiers(List<Identifier> identifiers) {
     this.identifiers = identifiers;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/links/HypermediaEnabledData.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/links/HypermediaEnabledData.java
@@ -45,7 +45,7 @@ public abstract class HypermediaEnabledData extends ExtensibleData implements Su
    */
   @Override
   @XmlElement (name = "link")
-  @JsonProperty ("links")
+  @JsonProperty ("links") @org.codehaus.jackson.annotate.JsonProperty ("links")
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RS )
   public List<Link> getLinks() {
     return links;
@@ -57,7 +57,7 @@ public abstract class HypermediaEnabledData extends ExtensibleData implements Su
    * @param links The list of hypermedia links. Links are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.
    */
   @Override
-  @JsonProperty ("links")
+  @JsonProperty ("links") @org.codehaus.jackson.annotate.JsonProperty ("links")
   public void setLinks(List<Link> links) {
     this.links = links;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/links/Link.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/links/Link.java
@@ -71,7 +71,7 @@ public class Link implements HasJsonKey {
   }
 
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @Override
   public boolean isHasUniqueKey() {
     return this.rel != null && !NON_UNIQUE_RELS.contains(this.rel);
@@ -83,7 +83,7 @@ public class Link implements HasJsonKey {
    * @return The link relationship.
    */
   @XmlAttribute
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public String getRel() {
     return rel;
   }
@@ -93,7 +93,7 @@ public class Link implements HasJsonKey {
    *
    * @param rel The link relationship.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setRel(String rel) {
     this.rel = rel;
   }
@@ -115,7 +115,7 @@ public class Link implements HasJsonKey {
    * @return The json key that is used define this link in a map.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @Override
   public String getJsonKey() {
     return getRel();
@@ -127,7 +127,7 @@ public class Link implements HasJsonKey {
    * @param jsonKey The json key that is used define this link in a map.
    */
   @Override
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setJsonKey(String jsonKey) {
     setRel(jsonKey);
   }
@@ -464,7 +464,7 @@ public class Link implements HasJsonKey {
    * @return The value of this link formatted per RFC 5988.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public String getHttpHeaderValue() {
     StringBuilder builder = new StringBuilder("<");
 

--- a/gedcomx-model/src/main/java/org/gedcomx/records/Collection.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/Collection.java
@@ -138,7 +138,7 @@ public class Collection extends HypermediaEnabledData implements Attributable {
    * @return The list of identifiers for the source.
    */
   @XmlElement(name="identifier")
-  @JsonProperty("identifiers")
+  @JsonProperty("identifiers") @org.codehaus.jackson.annotate.JsonProperty("identifiers")
   public List<Identifier> getIdentifiers() {
     return identifiers;
   }
@@ -148,7 +148,7 @@ public class Collection extends HypermediaEnabledData implements Attributable {
    *
    * @param identifiers The list of identifiers of the source.
    */
-  @JsonProperty ("identifiers")
+  @JsonProperty ("identifiers") @org.codehaus.jackson.annotate.JsonProperty ("identifiers")
   public void setIdentifiers(List<Identifier> identifiers) {
     this.identifiers = identifiers;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/records/CollectionContent.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/CollectionContent.java
@@ -108,7 +108,7 @@ public class CollectionContent extends HypermediaEnabledData {
    * @return The type of resource being covered in this collection.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public ResourceType getKnownResourceType() {
     return getResourceType() == null ? null : ResourceType.fromQNameURI(getResourceType());
   }
@@ -118,7 +118,7 @@ public class CollectionContent extends HypermediaEnabledData {
    *
    * @param type The type of resource being covered in this collection.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownResourceType(ResourceType type) {
     setResourceType(type == null ? null : type.toQNameURI());
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/records/Field.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/Field.java
@@ -117,7 +117,7 @@ public class Field extends Conclusion {
    * @return The type of the field.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public FieldType getKnownType() {
     return getType() == null ? null : FieldType.fromQNameURI(getType());
   }
@@ -127,7 +127,7 @@ public class Field extends Conclusion {
    *
    * @param type The type of the field.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(FieldType type) {
     setType(type == null ? null : type.toQNameURI());
   }
@@ -139,7 +139,7 @@ public class Field extends Conclusion {
    * @return The set of values for the field.
    */
   @XmlElement (name="value")
-  @JsonProperty ("values")
+  @JsonProperty ("values") @org.codehaus.jackson.annotate.JsonProperty ("values")
   public List<FieldValue> getValues() {
     return values;
   }
@@ -149,7 +149,7 @@ public class Field extends Conclusion {
    *
    * @param values The set of values for the field.
    */
-  @JsonProperty ("values")
+  @JsonProperty ("values") @org.codehaus.jackson.annotate.JsonProperty ("values")
   public void setValues(List<FieldValue> values) {
     this.values = values;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/records/FieldDescriptor.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/FieldDescriptor.java
@@ -97,7 +97,7 @@ public class FieldDescriptor extends HypermediaEnabledData {
    * @return The description of the field.
    */
   @XmlElement (name="description")
-  @JsonProperty ("descriptions")
+  @JsonProperty ("descriptions") @org.codehaus.jackson.annotate.JsonProperty ("descriptions")
   public List<TextValue> getDescriptions() {
     return descriptions;
   }
@@ -151,7 +151,7 @@ public class FieldDescriptor extends HypermediaEnabledData {
    * @return Descriptors of the values that are applicable to the field.
    */
   @XmlElement (name="value")
-  @JsonProperty ("values")
+  @JsonProperty ("values") @org.codehaus.jackson.annotate.JsonProperty ("values")
   public List<FieldValueDescriptor> getValues() {
     return values;
   }
@@ -161,7 +161,7 @@ public class FieldDescriptor extends HypermediaEnabledData {
    *
    * @param values Descriptors of the values that are applicable to the field.
    */
-  @JsonProperty ("values")
+  @JsonProperty ("values") @org.codehaus.jackson.annotate.JsonProperty ("values")
   public void setValues(List<FieldValueDescriptor> values) {
     this.values = values;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/records/FieldValue.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/FieldValue.java
@@ -189,7 +189,7 @@ public final class FieldValue extends Conclusion {
    * @return The type of the field value.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public FieldValueType getKnownType() {
     return getType() == null ? null : FieldValueType.fromQNameURI(getType());
   }
@@ -199,7 +199,7 @@ public final class FieldValue extends Conclusion {
    *
    * @param type The type of the field value.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(FieldValueType type) {
     setType(type == null ? null : type.toQNameURI());
   }
@@ -346,7 +346,7 @@ public final class FieldValue extends Conclusion {
    * @return The type of the field.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public FieldValueStatusType getKnownStatus() {
     return getType() == null ? null : FieldValueStatusType.fromQNameURI(getType());
   }
@@ -356,7 +356,7 @@ public final class FieldValue extends Conclusion {
    *
    * @param status The field value status type of the field.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownStatus(FieldValueStatusType status) {
     setType(status == null ? null : status.toQNameURI());
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/records/FieldValueDescriptor.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/FieldValueDescriptor.java
@@ -91,7 +91,7 @@ public class FieldValueDescriptor extends HypermediaEnabledData {
    * @return The type of the field value.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public FieldValueType getKnownType() {
     return getType() == null ? null : FieldValueType.fromQNameURI(getType());
   }
@@ -101,7 +101,7 @@ public class FieldValueDescriptor extends HypermediaEnabledData {
    *
    * @param type The type of the field value.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(FieldValueType type) {
     setType(type == null ? null : type.toQNameURI());
   }
@@ -131,7 +131,7 @@ public class FieldValueDescriptor extends HypermediaEnabledData {
    * @return The labels to be used for display purposes.
    */
   @XmlElement (name="label")
-  @JsonProperty ("labels")
+  @JsonProperty ("labels") @org.codehaus.jackson.annotate.JsonProperty ("labels")
   public List<TextValue> getDisplayLabels() {
     return displayLabels;
   }
@@ -141,7 +141,7 @@ public class FieldValueDescriptor extends HypermediaEnabledData {
    *
    * @param displayLabels The labels to be used for display purposes.
    */
-  @JsonProperty ("labels")
+  @JsonProperty ("labels") @org.codehaus.jackson.annotate.JsonProperty ("labels")
   public void setDisplayLabels(List<TextValue> displayLabels) {
     this.displayLabels = displayLabels;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/records/RecordDescriptor.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/RecordDescriptor.java
@@ -68,7 +68,7 @@ public class RecordDescriptor extends HypermediaEnabledData {
    * @return Descriptors of the fields that are applicable to this record.
    */
   @XmlElement (name="field")
-  @JsonProperty ("fields")
+  @JsonProperty ("fields") @org.codehaus.jackson.annotate.JsonProperty ("fields")
   public List<FieldDescriptor> getFields() {
     return fields;
   }
@@ -78,7 +78,7 @@ public class RecordDescriptor extends HypermediaEnabledData {
    *
    * @param fields Descriptors of the fields that are applicable to this record.
    */
-  @JsonProperty ("fields")
+  @JsonProperty ("fields") @org.codehaus.jackson.annotate.JsonProperty ("fields")
   public void setFields(List<FieldDescriptor> fields) {
     this.fields = fields;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/records/RecordSet.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/RecordSet.java
@@ -151,7 +151,7 @@ public class RecordSet extends HypermediaEnabledData {
    * @return The records included in this genealogical data set.
    */
   @XmlElement (name="record")
-  @JsonProperty ("records")
+  @JsonProperty ("records") @org.codehaus.jackson.annotate.JsonProperty ("records")
   public List<Gedcomx> getRecords() {
     return records;
   }
@@ -161,7 +161,7 @@ public class RecordSet extends HypermediaEnabledData {
    *
    * @param records The records included in this genealogical data set.
    */
-  @JsonProperty ("records")
+  @JsonProperty ("records") @org.codehaus.jackson.annotate.JsonProperty ("records")
   public void setRecords(List<Gedcomx> records) {
     this.records = records;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/source/CitationField.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/CitationField.java
@@ -53,7 +53,7 @@ public class CitationField implements HasJsonKey {
   }
 
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @Override
   public boolean isHasUniqueKey() {
     return true;
@@ -95,7 +95,7 @@ public class CitationField implements HasJsonKey {
    * @param name The citation field's name.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setNameValue(String name) {
     this.name = name != null ? new URI(name) : null;
   }
@@ -116,7 +116,7 @@ public class CitationField implements HasJsonKey {
    * @return The json key that is used define this link in a map.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @Override
   public String getJsonKey() {
     return getName().toString();
@@ -127,7 +127,7 @@ public class CitationField implements HasJsonKey {
    *
    * @param jsonKey The json key that is used define this link in a map.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @Override
   public void setJsonKey(String jsonKey) {
     setNameValue(jsonKey);

--- a/gedcomx-model/src/main/java/org/gedcomx/source/Coverage.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/Coverage.java
@@ -154,7 +154,7 @@ public class Coverage extends HypermediaEnabledData {
    * @return The type of record being covered in this collection, if any.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public RecordType getKnownRecordType() {
     return getRecordType() == null ? null : RecordType.fromQNameURI(getRecordType());
   }
@@ -164,7 +164,7 @@ public class Coverage extends HypermediaEnabledData {
    *
    * @param type The type of record being covered in this collection, if any.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownRecordType(RecordType type) {
     setRecordType(type == null ? null : type.toQNameURI());
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/source/SourceCitation.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/SourceCitation.java
@@ -159,7 +159,7 @@ public class SourceCitation extends HypermediaEnabledData {
    * @return The list of citation fields.
    */
   @XmlElement (name="field")
-  @JsonProperty ("fields")
+  @JsonProperty ("fields") @org.codehaus.jackson.annotate.JsonProperty ("fields")
   @Facet ( GedcomxConstants.FACET_GEDCOMX_CITATION )
   public List<CitationField> getFields() {
     return fields;
@@ -170,7 +170,7 @@ public class SourceCitation extends HypermediaEnabledData {
    *
    * @param fields The list of citation fields.
    */
-  @JsonProperty ("fields")
+  @JsonProperty ("fields") @org.codehaus.jackson.annotate.JsonProperty ("fields")
   public void setFields(List<CitationField> fields) {
     this.fields = fields;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/source/SourceDescription.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/SourceDescription.java
@@ -178,7 +178,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return The type of the resource being described.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public ResourceType getKnownType() {
     return getResourceType() == null ? null : ResourceType.fromQNameURI(getResourceType());
   }
@@ -188,7 +188,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param type The type of the resource being described.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKnownType(ResourceType type) {
     setResourceType(type == null ? null : type.toQNameURI());
   }
@@ -199,7 +199,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return The rights for this source.
    */
   @XmlElement ( name = "rights" )
-  @JsonProperty ( "rights" )
+  @JsonProperty ( "rights" ) @org.codehaus.jackson.annotate.JsonProperty ( "rights" )
   public List<URI> getRights() {
     return rights;
   }
@@ -209,7 +209,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param rights The rights for this source.
    */
-  @JsonProperty ( "rights" )
+  @JsonProperty ( "rights" ) @org.codehaus.jackson.annotate.JsonProperty ( "rights" )
   public void setRights(List<URI> rights) {
     this.rights = rights;
   }
@@ -244,7 +244,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return The preferred bibliographic citation for this source.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public SourceCitation getCitation() {
     return citations == null || citations.isEmpty() ? null : citations.get(0);
   }
@@ -255,7 +255,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return The bibliographic citations for this source.
    */
   @XmlElement ( name = "citation" )
-  @JsonProperty ( "citations" )
+  @JsonProperty ( "citations" ) @org.codehaus.jackson.annotate.JsonProperty ( "citations" )
   public List<SourceCitation> getCitations() {
     return citations;
   }
@@ -265,7 +265,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param citations The bibliographic citations for this source.
    */
-  @JsonProperty ( "citations" )
+  @JsonProperty ( "citations" ) @org.codehaus.jackson.annotate.JsonProperty ( "citations" )
   public void setCitations(List<SourceCitation> citations) {
     this.citations = citations;
   }
@@ -398,7 +398,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @param mediator A reference to the entity that mediates access to the described source.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setMediatorURI(URI mediator) {
     this.mediator = mediator != null ? new ResourceReference(mediator) : null;
   }
@@ -409,7 +409,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return References to any sources to which this source is related (usually applicable to sources that are derived from or contained in another source).
    */
   @XmlElement ( name = "source" )
-  @JsonProperty ( "sources" )
+  @JsonProperty ( "sources" ) @org.codehaus.jackson.annotate.JsonProperty ( "sources" )
   public List<SourceReference> getSources() {
     return sources;
   }
@@ -419,7 +419,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param sources References to any sources to which this source is related (usually applicable to sources that are derived from or contained in another source).
    */
-  @JsonProperty ( "sources" )
+  @JsonProperty ( "sources" ) @org.codehaus.jackson.annotate.JsonProperty ( "sources" )
   public void setSources(List<SourceReference> sources) {
     this.sources = sources;
   }
@@ -509,7 +509,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return The preferred title for this source description.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public TextValue getTitle() {
     return this.titles == null || this.titles.isEmpty() ? null : this.titles.get(0);
   }
@@ -520,7 +520,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return A list of titles for this source.
    */
   @XmlElement ( name = "title" )
-  @JsonProperty ( "titles" )
+  @JsonProperty ( "titles" ) @org.codehaus.jackson.annotate.JsonProperty ( "titles" )
   public List<TextValue> getTitles() {
     return titles;
   }
@@ -530,7 +530,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param titles A list of titles for this source.
    */
-  @JsonProperty ( "titles" )
+  @JsonProperty ( "titles" ) @org.codehaus.jackson.annotate.JsonProperty ( "titles" )
   public void setTitles(List<TextValue> titles) {
     this.titles = titles;
   }
@@ -593,7 +593,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return Notes about a source.
    */
   @XmlElement ( name = "note" )
-  @JsonProperty ( "notes" )
+  @JsonProperty ( "notes" ) @org.codehaus.jackson.annotate.JsonProperty ( "notes" )
   public List<Note> getNotes() {
     return notes;
   }
@@ -603,7 +603,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param notes Notes about a source.
    */
-  @JsonProperty ( "notes" )
+  @JsonProperty ( "notes" ) @org.codehaus.jackson.annotate.JsonProperty ( "notes" )
   public void setNotes(List<Note> notes) {
     this.notes = notes;
   }
@@ -664,7 +664,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return The long-term, persistent identifier for this source.
    */
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public URI getPersistentId() {
     URI identifier = null;
     if (this.identifiers != null) {
@@ -683,7 +683,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param persistentId A long-term, persistent, globally unique identifier for this source.
    */
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setPersistentId(URI persistentId) {
     if (this.identifiers == null) {
       this.identifiers = new ArrayList<Identifier>();
@@ -728,7 +728,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return The list of identifiers for the source.
    */
   @XmlElement ( name = "replaces" )
-  @JsonProperty ( "replaces" )
+  @JsonProperty ( "replaces" ) @org.codehaus.jackson.annotate.JsonProperty ( "replaces" )
   public List<URI> getReplaces() {
     return replaces;
   }
@@ -738,7 +738,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param replaces The list of identifiers of the source.
    */
-  @JsonProperty ( "replaces" )
+  @JsonProperty ( "replaces" ) @org.codehaus.jackson.annotate.JsonProperty ( "replaces" )
   public void setReplaces(List<URI> replaces) {
     this.replaces = replaces;
   }
@@ -749,7 +749,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return The list of status types for the source.
    */
   @XmlElement ( name = "status" )
-  @JsonProperty ( "statuses" )
+  @JsonProperty ( "statuses" ) @org.codehaus.jackson.annotate.JsonProperty ( "statuses" )
   public List<URI> getStatuses() {
     return statuses;
   }
@@ -759,7 +759,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param statuses The list of identifiers of the source.
    */
-  @JsonProperty ( "status" )
+  @JsonProperty ( "status" ) @org.codehaus.jackson.annotate.JsonProperty ( "status" )
   public void setStatuses(List<URI> statuses) {
     this.statuses = statuses;
   }
@@ -795,7 +795,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return The list of identifiers for the source.
    */
   @XmlElement ( name = "identifier" )
-  @JsonProperty ( "identifiers" )
+  @JsonProperty ( "identifiers" ) @org.codehaus.jackson.annotate.JsonProperty ( "identifiers" )
   public List<Identifier> getIdentifiers() {
     return identifiers;
   }
@@ -805,7 +805,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param identifiers The list of identifiers of the source.
    */
-  @JsonProperty ( "identifiers" )
+  @JsonProperty ( "identifiers" ) @org.codehaus.jackson.annotate.JsonProperty ( "identifiers" )
   public void setIdentifiers(List<Identifier> identifiers) {
     this.identifiers = identifiers;
   }
@@ -859,7 +859,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return Human-readable descriptions of the source.
    */
   @XmlElement ( name = "description" )
-  @JsonProperty ( "descriptions" )
+  @JsonProperty ( "descriptions" ) @org.codehaus.jackson.annotate.JsonProperty ( "descriptions" )
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<TextValue> getDescriptions() {
     return descriptions;
@@ -995,7 +995,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return The fields that are applicable to the resource being described.
    */
   @XmlElement ( name = "field" )
-  @JsonProperty ( "fields" )
+  @JsonProperty ( "fields" ) @org.codehaus.jackson.annotate.JsonProperty ( "fields" )
   @com.webcohesion.enunciate.metadata.Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public List<Field> getFields() {
     return fields;
@@ -1006,7 +1006,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param fields The fields that are applicable to the resource being described.
    */
-  @JsonProperty ( "fields" )
+  @JsonProperty ( "fields" ) @org.codehaus.jackson.annotate.JsonProperty ( "fields" )
   public void setFields(List<Field> fields) {
     this.fields = fields;
   }
@@ -1081,7 +1081,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    * @return Reference to a descriptor of fields and type of data that can be expected to be extracted from the source.
    */
   @XmlElement ( name = "descriptor" )
-  @JsonProperty ( "descriptor" )
+  @JsonProperty ( "descriptor" ) @org.codehaus.jackson.annotate.JsonProperty ( "descriptor" )
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RECORD )
   public ResourceReference getDescriptorRef() {
     return descriptorRef;
@@ -1092,7 +1092,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
    *
    * @param descriptorRef Reference to a descriptor of fields and type of data that can be expected to be extracted from the source.
    */
-  @JsonProperty ( "descriptor" )
+  @JsonProperty ( "descriptor" ) @org.codehaus.jackson.annotate.JsonProperty ( "descriptor" )
   public void setDescriptorRef(ResourceReference descriptorRef) {
     this.descriptorRef = descriptorRef;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/source/SourceReference.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/SourceReference.java
@@ -105,7 +105,7 @@ public class SourceReference extends HypermediaEnabledData implements Attributab
    * @return A reference to a description of the source being referenced.
    */
   @XmlAttribute ( name = "description" )
-  @JsonProperty ( "description" )
+  @JsonProperty ( "description" ) @org.codehaus.jackson.annotate.JsonProperty ( "description" )
   public URI getDescriptionRef() {
     return descriptionRef;
   }
@@ -115,7 +115,7 @@ public class SourceReference extends HypermediaEnabledData implements Attributab
    *
    * @param descriptionRef A reference to a description of the source being referenced.
    */
-  @JsonProperty ( "description" )
+  @JsonProperty ( "description" ) @org.codehaus.jackson.annotate.JsonProperty ( "description" )
   public void setDescriptionRef(URI descriptionRef) {
     this.descriptionRef = descriptionRef;
   }
@@ -137,7 +137,7 @@ public class SourceReference extends HypermediaEnabledData implements Attributab
    * @return Id of the source being referenced.
    */
   @XmlAttribute ( name = "descriptionId" )
-  @JsonProperty ( "descriptionId" )
+  @JsonProperty ( "descriptionId" ) @org.codehaus.jackson.annotate.JsonProperty ( "descriptionId" )
   public String getDescriptionId() {
     return descriptionId;
   }
@@ -147,7 +147,7 @@ public class SourceReference extends HypermediaEnabledData implements Attributab
    *
    * @param descriptionId Id of the source being referenced.
    */
-  @JsonProperty ( "descriptionId" )
+  @JsonProperty ( "descriptionId" ) @org.codehaus.jackson.annotate.JsonProperty ( "descriptionId" )
   public void setDescriptionId(String descriptionId) {
     this.descriptionId = descriptionId;
   }
@@ -182,7 +182,7 @@ public class SourceReference extends HypermediaEnabledData implements Attributab
    * @return The qualifiers associated with this source reference.
    */
   @XmlElement (name = "qualifier")
-  @JsonProperty ("qualifiers")
+  @JsonProperty ("qualifiers") @org.codehaus.jackson.annotate.JsonProperty ("qualifiers")
   public List<Qualifier> getQualifiers() {
     return qualifiers;
   }
@@ -192,7 +192,7 @@ public class SourceReference extends HypermediaEnabledData implements Attributab
    *
    * @param qualifiers qualifiers to associate with this source reference.
    */
-  @JsonProperty ("qualifiers")
+  @JsonProperty ("qualifiers") @org.codehaus.jackson.annotate.JsonProperty ("qualifiers")
   public void setQualifiers(List<Qualifier> qualifiers) {
     this.qualifiers = qualifiers;
   }

--- a/gedcomx-model/src/main/java/org/gedcomx/util/HasIdentifiersMixin.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/util/HasIdentifiersMixin.java
@@ -34,7 +34,7 @@ abstract class HasIdentifiersMixin {
    *
    * @return The list of identifiers for the agent.
    */
-  @JsonProperty ("identifiers")
+  @JsonProperty ("identifiers") @org.codehaus.jackson.annotate.JsonProperty ("identifiers")
   public abstract Map<String, List<String>> getIdentifiers();
 
   /**
@@ -42,7 +42,7 @@ abstract class HasIdentifiersMixin {
    *
    * @param identifiers The list of identifiers of the agent.
    */
-  @JsonProperty ("identifiers")
+  @JsonProperty ("identifiers") @org.codehaus.jackson.annotate.JsonProperty ("identifiers")
   public abstract void setIdentifiers(Map<String, List<String>> identifiers);
 
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/util/HasLinksMixin.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/util/HasLinksMixin.java
@@ -36,7 +36,7 @@ abstract class HasLinksMixin {
    *
    * @return The list of hypermedia links. Links are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.
    */
-  @JsonProperty ("links")
+  @JsonProperty ("links") @org.codehaus.jackson.annotate.JsonProperty ("links")
   @Facet ( GedcomxConstants.FACET_GEDCOMX_RS )
   public abstract Map<String, Link> getLinks();
 
@@ -45,7 +45,7 @@ abstract class HasLinksMixin {
    *
    * @param links The list of hypermedia links. Links are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.
    */
-  @JsonProperty ("links")
+  @JsonProperty ("links") @org.codehaus.jackson.annotate.JsonProperty ("links")
   public abstract void setLinks(Map<String, Link> links);
 
 }

--- a/gedcomx-model/src/test/java/org/gedcomx/common/CustomKeyedItem.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/common/CustomKeyedItem.java
@@ -18,32 +18,32 @@ public class CustomKeyedItem implements HasJsonKey {
   private String val1;
   private String val2;
 
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @XmlTransient
   @Override
   public boolean isHasUniqueKey() {
     return false;
   }
 
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @XmlTransient
   @Override
   public String getJsonKey() {
     return getKey();
   }
 
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @Override
   public void setJsonKey(String jsonKey) {
     setKey(jsonKey);
   }
 
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public String getKey() {
     return key;
   }
 
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKey(String key) {
     this.key = key;
   }

--- a/gedcomx-model/src/test/java/org/gedcomx/common/UniqueCustomKeyedItem.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/common/UniqueCustomKeyedItem.java
@@ -19,31 +19,31 @@ public class UniqueCustomKeyedItem implements HasJsonKey {
   private String val2;
 
   @XmlTransient
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @Override
   public boolean isHasUniqueKey() {
     return true;
   }
 
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @XmlTransient
   @Override
   public String getJsonKey() {
     return getKey();
   }
 
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   @Override
   public void setJsonKey(String jsonKey) {
     setKey(jsonKey);
   }
 
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public String getKey() {
     return key;
   }
 
-  @JsonIgnore
+  @JsonIgnore @org.codehaus.jackson.annotate.JsonIgnore
   public void setKey(String key) {
     this.key = key;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <root.basedir>${project.basedir}</root.basedir>
     <jersey.version>1.19.2</jersey.version>
     <jackson.version>2.7.8</jackson.version>
+    <jackson1.version>1.9.13</jackson1.version>
 
     <skip.javadoc>true</skip.javadoc>
     <skip.pgp>true</skip.pgp>
@@ -80,6 +81,12 @@
         <groupId>com.fasterxml.woodstox</groupId>
         <artifactId>woodstox-core</artifactId>
         <version>5.0.3</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-core-asl</artifactId>
+        <version>${jackson1.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Jackson 2 is still the main version and is fully supported.
Jackson 1 support doesn't need to be full fledged anymore,
but let's at least leave the Jackson 1 annotations for consumers that use both Jackson 1 and Jackson 2.