### PR TITLE
Upgrade to jaxb 2.2.11 which is org.glassfish.jaxb:jaxb-runtime

### DIFF
--- a/gedcomx-rt-support/pom.xml
+++ b/gedcomx-rt-support/pom.xml
@@ -38,11 +38,11 @@
     </dependency>
 
     <!--
-        we explicitly depend on jaxb-impl in order to implement the namespace prefix mapper.
+        we explicitly depend on jaxb-runtime in order to implement the namespace prefix mapper.
     -->
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,9 @@
       </dependency>
 
       <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <version>2.2.7</version>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-runtime</artifactId>
+        <version>2.2.11</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
See https://stackoverflow.com/a/26413432/1048373
This will eliminate the dependency on javax.xml.bind:jsr173_api
which duplicates classes in xml-apis:xml-apis