### PR TITLE
GedcomxDateSimple no longer supports year zero.

### DIFF
--- a/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateSimple.java
+++ b/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateSimple.java
@@ -73,6 +73,10 @@ public class GedcomxDateSimple extends GedcomxDate {
 
     year = Integer.valueOf(num);
 
+    if(year == 0) {
+      throw new GedcomxDateException("Invalid Date: Year 0000 does not exist in Anno Domini (AD) system");
+    }
+
     if(offset == end) {
       return;
     }

--- a/gedcomx-date/src/test/java/org/gedcomx/date/SimpleTest.java
+++ b/gedcomx-date/src/test/java/org/gedcomx/date/SimpleTest.java
@@ -60,9 +60,23 @@ public class SimpleTest {
   }
 
   @Test
-  public void successOnNegativeYearZero() {
-    GedcomxDateSimple date = new GedcomxDateSimple("-0000");
-    assertThat(date.getYear()).isEqualTo(0);
+  public void errorOnYearZero() {
+    try {
+      new GedcomxDateSimple("+0000");
+      fail("GedcomxDateException expected because the year 0000 is invalid");
+    } catch(GedcomxDateException e) {
+      assertThat(e.getMessage()).isEqualTo("Invalid Date: Year 0000 does not exist in Anno Domini (AD) system");
+    }
+  }
+
+  @Test
+  public void errorOnNegativeYearZero() {
+    try {
+      new GedcomxDateSimple("-0000");
+      fail("GedcomxDateException expected because the year -0000 is invalid");
+    } catch(GedcomxDateException e) {
+      assertThat(e.getMessage()).isEqualTo("Invalid Date: Year 0000 does not exist in Anno Domini (AD) system");
+    }
   }
 
   @Test


### PR DESCRIPTION
The year zero does not exist in the Anno Domini (AD) system.