### PR TITLE
Fix EnumURIMap to handle URI fragments

### DIFF
--- a/extensions/familysearch/familysearch-api-model/src/test/java/org/familysearch/platform/rt/EnumURIMapTest.java
+++ b/extensions/familysearch/familysearch-api-model/src/test/java/org/familysearch/platform/rt/EnumURIMapTest.java
@@ -1,0 +1,22 @@
+package org.familysearch.platform.rt;
+
+import org.gedcomx.common.URI;
+import org.gedcomx.rt.EnumURIMap;
+import org.gedcomx.rt.GedcomxConstants;
+import org.gedcomx.types.ResourceType;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+public class EnumURIMapTest {
+
+  @Test
+  public void testLookUpURIWithFragment() {
+    EnumURIMap<ResourceType> uriMap = new EnumURIMap<>(ResourceType.class, GedcomxConstants.GEDCOMX_TYPES_NAMESPACE);
+    URI uriWithoutFragment = ResourceType.DigitalArtifact.toQNameURI();
+    Assert.assertEquals(ResourceType.DigitalArtifact, uriMap.fromURIValue(uriWithoutFragment));
+    URI uriWithFragment = URI.create(ResourceType.DigitalArtifact.toQNameURI().toString()+"#uriFragment");
+    Assert.assertEquals(ResourceType.DigitalArtifact, uriMap.fromURIValue(uriWithFragment));
+
+
+  }
+}

--- a/gedcomx-model/src/main/java/org/gedcomx/rt/EnumURIMap.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/rt/EnumURIMap.java
@@ -133,6 +133,10 @@ public class EnumURIMap<K extends Enum<K>> extends EnumMap<K, String> {
       }
     }
 
+    if (token.contains("#")) {
+      //try it without the URI fragment to see if there is a primary resource this URI refers to
+      return fromURIValue(URI.create(token.substring(0, token.indexOf("#"))));
+    }
     //still not found; return the unknown value.
     return unknownValue;
   }


### PR DESCRIPTION
A URI fragment is the portion of a URI following a hash mark (#). It refers to a resource that
is subordinate to a primary resource. This change says that if the URI with a fragment is not found
in the EnumURIMap, look for the primary resource without the fragment.