### PR TITLE
Add extension support for Vocab translations, and definitions in VocabConcept

### DIFF
--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/rt/FamilySearchPlatformModelVisitor.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/rt/FamilySearchPlatformModelVisitor.java
@@ -24,6 +24,7 @@ import org.familysearch.platform.discussions.Discussion;
 import org.familysearch.platform.users.User;
 import org.familysearch.platform.vocab.VocabConcept;
 import org.familysearch.platform.vocab.VocabTerm;
+import org.familysearch.platform.vocab.VocabTranslation;
 
 import org.gedcomx.rt.GedcomxModelVisitor;
 
@@ -48,5 +49,7 @@ public interface FamilySearchPlatformModelVisitor extends GedcomxModelVisitor {
   void visitVocabConcept(VocabConcept vocabConcept);
 
   void visitVocabTerm(VocabTerm vocabTerm);
+
+  void visitVocabTranslation(VocabTranslation vocabTranslation);
 
 }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/rt/FamilySearchPlatformModelVisitorBase.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/rt/FamilySearchPlatformModelVisitorBase.java
@@ -25,6 +25,7 @@ import org.familysearch.platform.users.User;
 import org.familysearch.platform.vocab.VocabConcept;
 import org.familysearch.platform.vocab.VocabTerm;
 
+import org.familysearch.platform.vocab.VocabTranslation;
 import org.gedcomx.Gedcomx;
 import org.gedcomx.conclusion.Fact;
 import org.gedcomx.rt.GedcomxModelVisitorBase;
@@ -231,6 +232,11 @@ public class FamilySearchPlatformModelVisitorBase extends GedcomxModelVisitorBas
 
   @Override
   public void visitVocabTerm(VocabTerm vocabTerm) {
+    //no-op.
+  }
+
+  @Override
+  public void visitVocabTranslation(VocabTranslation vocabTranslation) {
     //no-op.
   }
 }

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/vocab/VocabConcept.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/vocab/VocabConcept.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.gedcomx.common.TextValue;
 import org.gedcomx.common.URI;
 import org.gedcomx.links.HypermediaEnabledData;
 import org.gedcomx.rt.json.JsonElementWrapper;
@@ -39,6 +40,7 @@ public class VocabConcept extends HypermediaEnabledData {
   private URI gedcomxUri;
   private List<VocabTerm> vocabTerms;
   private List<VocabConceptAttribute> attributes;
+  private List<TextValue> definitions;
 
   /**
    * Get the vocabulary concept description.
@@ -194,6 +196,35 @@ public class VocabConcept extends HypermediaEnabledData {
    */
   public VocabConcept attributes(final List<VocabConceptAttribute> attributes) {
     this.setAttributes(attributes);
+    return this;
+  }
+
+  /**
+   * Get the definitions associated with this vocabulary concept.
+   *
+   * @return The definitions associated with this vocabulary concept.
+   */
+  public List<TextValue> getDefinitions() {
+    return definitions;
+  }
+
+  /**
+   * Set the definitions associated with this vocabulary concept.
+   *
+   * @param definitions The definitions associated with this vocabulary concept.
+   */
+  public void setDefinitions(List<TextValue> definitions) {
+    this.definitions = definitions;
+  }
+
+  /**
+   * Build out this vocabulary concept by applying the given list of definitions.
+   *
+   * @param definitions The definitions to apply to this vocabulary concept.
+   * @return this.
+   */
+  public VocabConcept definitions(final List<TextValue> definitions) {
+    this.setDefinitions(definitions);
     return this;
   }
 

--- a/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/vocab/VocabTranslation.java
+++ b/extensions/familysearch/familysearch-api-model/src/main/java/org/familysearch/platform/vocab/VocabTranslation.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright Intellectual Reserve, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.familysearch.platform.vocab;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.familysearch.platform.rt.FamilySearchPlatformModelVisitor;
+import org.gedcomx.common.TextValue;
+import org.gedcomx.common.URI;
+import org.gedcomx.links.HypermediaEnabledData;
+import org.gedcomx.rt.json.JsonElementWrapper;
+
+@XmlRootElement
+@JsonElementWrapper(name = "vocabTranslations")
+@XmlType(name = "VocabTranslation")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class VocabTranslation extends HypermediaEnabledData {
+  private TextValue translation;
+
+  public VocabTranslation() {
+    translation = new TextValue();
+  }
+
+  public VocabTranslation(TextValue translation) {
+    this.translation = translation;
+  }
+
+  public VocabTranslation(String text, String language) {
+    translation = new TextValue().lang(language).value(text);
+  }
+
+
+  /**
+   * Get the language of the vocabulary translation. See
+   * <a href="http://www.w3.org/International/articles/language-tags/">http://www.w3.org/International/articles/language-tags/</a>
+   *
+   * @return the language for the translation.
+   */
+  public String getLang() {
+    return translation.getLang();
+  }
+
+  /**
+   * Set the language for the vocabulary translation. See
+   * <a href="http://www.w3.org/International/articles/language-tags/">http://www.w3.org/International/articles/language-tags/</a>
+   *
+   * @param lang The language for the vocabulary translation
+   */
+  public void setLang(String lang) {
+    translation.setLang(lang);
+  }
+
+  /**
+   * Build up this vocabulary translation with a specified language. See
+   * <a href="http://www.w3.org/International/articles/language-tags/">http://www.w3.org/International/articles/language-tags/</a>
+   *
+   * @param lang The language for the vocabulary translation.
+   * @return this.
+   */
+  public VocabTranslation lang(String lang) {
+    translation.setLang(lang);
+    return this;
+  }
+
+
+  /**
+   * Get the text for this vocabulary translation.
+   *
+   * @return the translation text.
+   */
+  public String getText() {
+    return translation.getValue();
+  }
+
+  /**
+   * Set the text for this vocabulary translation
+   *
+   * @param text The translation text
+   */
+  public void setText(String text) {
+    translation.setValue(text);
+  }
+
+  /**
+   * Build up this vocabulary translation with a translation text.
+   *
+   * @param text The text value.
+   * @return this.
+   */
+  public VocabTranslation text(String text) {
+    translation.setValue(text);
+    return this;
+  }
+
+    /**
+     * Accept a visitor.
+     *
+     * @param visitor The visitor to accept.
+     */
+  public void accept(FamilySearchPlatformModelVisitor visitor) {
+    visitor.visitVocabTranslation(this);
+  }
+
+  public void embed(VocabTranslation vocabTerm) {
+    super.embed(vocabTerm);
+  }
+
+}

--- a/extensions/familysearch/familysearch-api-model/src/test/java/org/familysearch/platform/vocab/VocabConceptTest.java
+++ b/extensions/familysearch/familysearch-api-model/src/test/java/org/familysearch/platform/vocab/VocabConceptTest.java
@@ -87,6 +87,23 @@ public class VocabConceptTest {
   }
 
   @Test
+  public void testDefinitions() {
+    final TextValue definition = new TextValue("testDefinitionEn").lang("en");
+    List<TextValue> testDefinitions = Collections.singletonList(definition);
+
+    // Test using setter
+    VocabConcept classUnderTest = new VocabConcept();
+    classUnderTest.setDefinitions(testDefinitions);
+
+    assertEquals(classUnderTest.getDefinitions(), testDefinitions);
+
+    // Test using builder pattern method
+    classUnderTest = new VocabConcept().definitions(testDefinitions);
+
+    assertEquals(classUnderTest.getDefinitions(), testDefinitions);
+  }
+
+  @Test
   public void testAttributes() {
     final VocabConceptAttribute testVocabConceptAttribute = new VocabConceptAttribute()
         .id("testId")

--- a/extensions/familysearch/familysearch-api-model/src/test/java/org/familysearch/platform/vocab/VocabTranslationTest.java
+++ b/extensions/familysearch/familysearch-api-model/src/test/java/org/familysearch/platform/vocab/VocabTranslationTest.java
@@ -1,0 +1,57 @@
+package org.familysearch.platform.vocab;
+
+import org.gedcomx.common.TextValue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VocabTranslationTest {
+
+    private final String lang = "de";
+    private final String text = "die Prüfung"; // "the test"
+    private final TextValue textValue = new TextValue(text).lang(lang);
+
+    @Test
+    public void testLang() {
+        // Test using setter
+        VocabTranslation classUnderTest = new VocabTranslation();
+        classUnderTest.setLang(lang);
+
+        assertEquals(classUnderTest.getLang(), lang);
+
+        // Test using builder pattern method
+        classUnderTest = new VocabTranslation().lang(lang);
+
+        assertEquals(classUnderTest.getLang(), lang);
+
+        // Test using TextValue constructor
+        classUnderTest = new VocabTranslation(textValue);
+
+        assertEquals(classUnderTest.getLang(), lang);
+
+        // Test constructor with parameters
+        classUnderTest = new VocabTranslation(text, lang);
+
+        assertEquals(classUnderTest.getLang(), lang);
+    }
+
+    @Test
+    public void testText() {
+        // Test using setter
+        VocabTranslation classUnderTest = new VocabTranslation();
+        classUnderTest.setText(text);
+
+        assertEquals(classUnderTest.getText(), text);
+
+        // Test using builder pattern method
+        classUnderTest = new VocabTranslation().text(text);
+
+        assertEquals(classUnderTest.getText(), text);
+
+        // Test using TextValue constructor
+        classUnderTest = new VocabTranslation(textValue);
+
+        assertEquals(classUnderTest.getText(), text);
+    }
+
+}


### PR DESCRIPTION
Endpoints are being introduced in Platform API that request, update, or add translations for VocabTerms and VocabConcept definitions. (There is no need for the entire Term or Concept, just the text and associated language.)

Localized definitions were added to Concepts over 2 years ago, but are missing in the VocabConcept model. We need to be able to export this field in order for additional translations to be generated by a partner/vendor.