### PR TITLE
Improve build performance by turning off report generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
     <pgp-maven-plugin.version>1.1</pgp-maven-plugin.version>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <modules>
@@ -247,6 +248,7 @@
           <configuration>
           	<parallel>classes</parallel>
           	<useUnlimitedThreads>true</useUnlimitedThreads>
+        	<disableXmlReport>${closeTestReports}</disableXmlReport>
           </configuration>
 
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
     <pgp-maven-plugin.version>1.1</pgp-maven-plugin.version>
-  	<closeTestReports>true</closeTestReports>
+    <closeTestReports>true</closeTestReports>
   </properties>
 
   <modules>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
