### PR TITLE
Implement Comparable on GedcomxDate

### DIFF
--- a/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDate.java
+++ b/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDate.java
@@ -19,7 +19,7 @@ package org.gedcomx.date;
  * A Formal Gedcomx Date
  * @author John Clark.
  */
-public abstract class GedcomxDate {
+public abstract class GedcomxDate implements Comparable<GedcomxDate> {
 
   /**
    * Return the type of date
@@ -38,5 +38,17 @@ public abstract class GedcomxDate {
    * @return The formal string
    */
   public abstract String toFormalString();
+
+  /**
+   * This method MAY not be implemented for each subclass.  Specific behavior should be documented
+   * in each subclass implementation.
+   * @param o the object to be compared.
+   * @return If implemented - a negative integer, zero, or a positive integer as this object is less than, equal to, or greater than the specified object
+   * @throws UnsupportedOperationException if the sublcass does not support this method.
+   */
+  @Override
+  public int compareTo(GedcomxDate o) {
+    throw new UnsupportedOperationException();
+  }
 
 }

--- a/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateApproximate.java
+++ b/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateApproximate.java
@@ -135,4 +135,15 @@ public class GedcomxDateApproximate extends GedcomxDate {
   public Integer getTzMinutes() {
     return simpleDate.getTzMinutes();
   }
+
+  /**
+   * Calls the <code>compareTo</code> method on the simple date that this GedcomxDateApproximate contains.
+   * See {@link GedcomxDateSimple#compareTo(GedcomxDate)} for more information
+   * @param other the object to be compared.
+   * @return a negative integer, zero, or a positive integer as this object is less than, equal to, or greater than the specified object
+   */
+  @Override
+  public int compareTo(GedcomxDate other) {
+    return this.simpleDate.compareTo(other);
+  }
 }

--- a/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateSimple.java
+++ b/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateSimple.java
@@ -15,8 +15,11 @@
  */
 package org.gedcomx.date;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.Optional;
 import java.util.TimeZone;
 
 /**
@@ -482,5 +485,50 @@ public class GedcomxDateSimple extends GedcomxDate {
    */
   public Integer getTzMinutes() {
     return tzMinutes;
+  }
+
+  /**
+   * Compares this GedcomxDateSimple object with either another GedcomxDateSimple object
+   * or a GedcomxDateApproximate object.
+   * @param other the object to be compared.
+   * @return a negative integer, zero, or a positive integer as this object is less than, equal to, or greater than the specified object
+   * @throws ClassCastException if other is not of type GedcomxDateSimple or GedcomxDateApproximate
+   * @throws NullPointerException if other is null
+   */
+  @Override
+  public int compareTo(GedcomxDate other) {
+    if (other == null) {
+      throw new NullPointerException();
+    }
+    GedcomxDateSimple o;
+    if (other instanceof GedcomxDateSimple) {
+      o = (GedcomxDateSimple) other;
+    } else if (other instanceof GedcomxDateApproximate) {
+      o = ((GedcomxDateApproximate) other).getSimpleDate();
+    } else {
+      throw new ClassCastException("other is not an instance of either GedcomxDateSimple or GedcomxDateApproximate");
+    }
+    String isoFormat = "%d-%02d-%02dT%02d:%02d:%02d%+03d:%02d";
+    String isoThisDate = String.format(isoFormat,
+            this.getYear(),
+            Optional.ofNullable(this.getMonth()).orElse(1),
+            Optional.ofNullable(this.getDay()).orElse(1),
+            Optional.ofNullable(this.getHours()).orElse(0),
+            Optional.ofNullable(this.getMinutes()).orElse(0),
+            Optional.ofNullable(this.getSeconds()).orElse(0),
+            Optional.ofNullable(this.getTzHours()).orElse(0),
+            Optional.ofNullable(this.getTzMinutes()).orElse(0));
+    String isoOtherDate = String.format(isoFormat,
+            o.getYear(),
+            Optional.ofNullable(o.getMonth()).orElse(1),
+            Optional.ofNullable(o.getDay()).orElse(1),
+            Optional.ofNullable(o.getHours()).orElse(0),
+            Optional.ofNullable(o.getMinutes()).orElse(0),
+            Optional.ofNullable(o.getSeconds()).orElse(0),
+            Optional.ofNullable(o.getTzHours()).orElse(0),
+            Optional.ofNullable(o.getTzMinutes()).orElse(0));
+    Instant thisInstant = DateTimeFormatter.ISO_INSTANT.parse(isoThisDate, Instant::from);
+    Instant otherInstant = DateTimeFormatter.ISO_INSTANT.parse(isoOtherDate, Instant::from);
+    return thisInstant.compareTo(otherInstant);
   }
 }

--- a/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateSimple.java
+++ b/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateSimple.java
@@ -489,7 +489,13 @@ public class GedcomxDateSimple extends GedcomxDate {
 
   /**
    * Compares this GedcomxDateSimple object with either another GedcomxDateSimple object
-   * or a GedcomxDateApproximate object.
+   * or a GedcomxDateApproximate object.  Comparison is achieved by using an ISO 8601 date
+   * format using the populated temporal fields in this object amd the fields in the other
+   * object.  If a field is null it defaults to a "0th" value.  So in the case of the simplest
+   * date of only a year field value it would default to January 1 at midnight UTC of the
+   * given year.  ISO 8601 conversion occurs for both <code>this</code> and <code>other</code>.
+   * In other words, if there is missing field information it will reflect as the earliest
+   * possible ISO 8601 representation of the object to use in comparison.
    * @param other the object to be compared.
    * @return a negative integer, zero, or a positive integer as this object is less than, equal to, or greater than the specified object
    * @throws ClassCastException if other is not of type GedcomxDateSimple or GedcomxDateApproximate

--- a/gedcomx-date/src/test/java/org/gedcomx/date/SimpleTest.java
+++ b/gedcomx-date/src/test/java/org/gedcomx/date/SimpleTest.java
@@ -1,5 +1,6 @@
 package org.gedcomx.date;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -611,4 +612,163 @@ public class SimpleTest {
     }
   }
 
+  @Test
+  public void testCompareTo() {
+    GedcomxDateSimple before = new GedcomxDateSimple("+1000-01-01T10:00:00Z");
+    GedcomxDateSimple after = new GedcomxDateSimple("+1000-01-02T10:00:00Z");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testCompareToPartialDateYear() {
+    GedcomxDateSimple before = new GedcomxDateSimple("+1000");
+    GedcomxDateSimple after = new GedcomxDateSimple("+1001");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testCompareToPartialDateYearMonth() {
+    GedcomxDateSimple before = new GedcomxDateSimple("+1000-01");
+    GedcomxDateSimple after = new GedcomxDateSimple("+1000-02");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testCompareToPartialDateYearMonthDay() {
+    GedcomxDateSimple before = new GedcomxDateSimple("+1000-01-01");
+    GedcomxDateSimple after = new GedcomxDateSimple("+1000-01-02");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testCompareToPartialDateYearMonthDayHour() {
+    GedcomxDateSimple before = new GedcomxDateSimple("+1000-01-01T08");
+    GedcomxDateSimple after = new GedcomxDateSimple("+1000-01-01T09");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testCompareToPartialDateYearMonthDayHourMinute() {
+    GedcomxDateSimple before = new GedcomxDateSimple("+1000-01-01T08:10");
+    GedcomxDateSimple after = new GedcomxDateSimple("+1000-01-01T08:12");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testCompareToPartialDateYearMonthDayHourMinuteSeconds() {
+    GedcomxDateSimple before = new GedcomxDateSimple("+1000-01-01T08:10:00");
+    GedcomxDateSimple after = new GedcomxDateSimple("+1000-01-01T08:10:01");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testCompareToPartialDateYearMonthDayHourMinuteSecondsTzHours() {
+    GedcomxDateSimple before = new GedcomxDateSimple("+1000-01-01T08:10:00+00");
+    GedcomxDateSimple after = new GedcomxDateSimple("+1000-01-01T08:09:01-01");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testCompareToPartialDateYearMonthDayHourMinuteSecondsTzHoursTzMinutes() {
+    GedcomxDateSimple before = new GedcomxDateSimple("+1000-01-01T08:10:00-01:00");
+    GedcomxDateSimple after = new GedcomxDateSimple("+1000-01-01T08:09:31-01:30");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testCompareToBCEYear() {
+    GedcomxDateSimple before = new GedcomxDateSimple("-1001");
+    GedcomxDateSimple after = new GedcomxDateSimple("-1000");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testCompareToApproximateYear() {
+    GedcomxDateSimple before = new GedcomxDateSimple("+1000");
+    GedcomxDateApproximate after = new GedcomxDateApproximate("A+1001");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testBaseClassCompareToApproximateYear() {
+    GedcomxDate before = GedcomxDateUtil.parse("+1000");
+    GedcomxDate after = GedcomxDateUtil.parse("A+1001");
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(after))
+            .isLessThan(0);
+    org.assertj.core.api.Assertions.assertThat(after.compareTo(before))
+            .isGreaterThan(0);
+    org.assertj.core.api.Assertions.assertThat(before.compareTo(before))
+            .isEqualTo(0);
+  }
+
+  @Test
+  public void testBaseClassCompareToClassCastException() {
+    GedcomxDate before = GedcomxDateUtil.parse("+1000");
+    GedcomxDate after = GedcomxDateUtil.parse("A+1001/+1002");
+    org.assertj.core.api.Assertions.assertThatExceptionOfType(ClassCastException.class)
+            .isThrownBy(() -> before.compareTo(after))
+            .withMessage("other is not an instance of either GedcomxDateSimple or GedcomxDateApproximate");
+  }
+
+  @Test
+  public void testBaseClassCompareToNullPointerException() {
+    GedcomxDate before = GedcomxDateUtil.parse("+1000");
+    org.assertj.core.api.Assertions.assertThatExceptionOfType(NullPointerException.class)
+            .isThrownBy(() -> before.compareTo(null));
+  }
 }


### PR DESCRIPTION
This implements Comparable in a limited fashion on GedcomxDates.  The default behavior is to throw an UnsupportedOperationException and it is up to the subclasses to implement the method if so desired.  GedcomxDateSimple and GedcomxDateApproximate have an implementation.