### PR TITLE
GedcomxDateRange ends are now inclusive of the specified end date.

### DIFF
--- a/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateException.java
+++ b/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateException.java
@@ -29,4 +29,8 @@ public class GedcomxDateException extends RuntimeException {
     super(msg);
   }
 
+  public GedcomxDateException(String msg, Throwable cause) {
+    super(msg, cause);
+  }
+
 }

--- a/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateSimple.java
+++ b/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateSimple.java
@@ -16,6 +16,7 @@
 package org.gedcomx.date;
 
 import java.time.Instant;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Optional;
@@ -166,7 +167,7 @@ public class GedcomxDateSimple extends GedcomxDate {
       throw new GedcomxDateException("Invalid Date: Day 0 does not exist");
     }
 
-    int daysInMonth = GedcomxDateUtil.daysInMonth(month, year);
+    int daysInMonth = YearMonth.of(year, month).lengthOfMonth();
     if(day > daysInMonth) {
       throw new GedcomxDateException("Invalid Date: There are only "+daysInMonth+" days in Month "+month+" year "+year);
     }

--- a/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateUtil.java
+++ b/gedcomx-date/src/main/java/org/gedcomx/date/GedcomxDateUtil.java
@@ -15,7 +15,7 @@
  */
 package org.gedcomx.date;
 
-import java.time.LocalDateTime;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
@@ -43,15 +43,18 @@ public class GedcomxDateUtil {
       throw new GedcomxDateException("Invalid Date");
     }
 
+    GedcomxDate retVal;
+    // This order is critical because the date types are not mutually exclusive
     if(date.charAt(0) == 'R') {
-      return new GedcomxDateRecurring(date);
+      retVal = new GedcomxDateRecurring(date);
     } else if(date.contains("/")) {
-      return new GedcomxDateRange(date);
+      retVal = new GedcomxDateRange(date);
     } else if(date.charAt(0) == 'A') {
-      return new GedcomxDateApproximate(date);
+      retVal = new GedcomxDateApproximate(date);
     } else {
-      return new GedcomxDateSimple(date);
+      retVal = new GedcomxDateSimple(date);
     }
+    return retVal;
   }
 
   /**
@@ -62,96 +65,97 @@ public class GedcomxDateUtil {
    */
   public static GedcomxDateDuration getDuration(GedcomxDateSimple startDate, GedcomxDateSimple endDate) {
 
-    if(startDate == null || endDate == null) {
+    if (startDate == null || endDate == null) {
       throw new GedcomxDateException("Start and End must be simple dates");
     }
 
-    Date start = new Date(startDate, true);
-    Date end = new Date(endDate, true);
+    LocalDateTime start = getMinLocalDateTime(startDate);
+    LocalDateTime end = getMaxLocalDateTime(endDate);
 
-    if(end.year-start.year < 0) {
-      throw new GedcomxDateException("Start Date=" + startDate.toFormalString() + " must be less than End Date=" + endDate.toFormalString());
+    Period p = Period.between(start.toLocalDate(), end.toLocalDate());
+    Duration d = Duration.between(start.toLocalTime(), end.toLocalTime());
+
+    // If the time is negative, we need to roll up the day that we date from the date portion
+    // if the date is zero or negative, the exception below will be triggered.
+    if (d.isNegative()) {
+      p = p.minusDays(1);
+      d = d.plusDays(1);
     }
 
-    boolean hasTime = false;
-    StringBuilder duration = new StringBuilder();
-
-    zipDates(start, end);
-
-    // Build the duration backwards so we can grab the correct diff
-    // Also we need to roll everything up so we don't generate an invalid max year
-    if(end.seconds != null) {
-      while(end.seconds-start.seconds < 0) {
-        end.minutes -= 1;
-        end.seconds += 60;
-      }
-      if(end.seconds-start.seconds > 0) {
-        hasTime = true;
-        duration.insert(0,'S').insert(0,String.format("%02d", end.seconds - start.seconds));
-      }
+    if(p.isNegative() || (p.isZero() && d.isNegative())) {
+      throw new GedcomxDateException(String.format("Start Date=%s must be less than End Date=%s", startDate.toFormalString(), endDate.toFormalString()));
     }
 
-    if(end.minutes != null) {
-      while(end.minutes-start.minutes < 0) {
-        end.hours -= 1;
-        end.minutes += 60;
-      }
-      if(end.minutes-start.minutes > 0) {
-        hasTime = true;
-        duration.insert(0,'M').insert(0,String.format("%02d", end.minutes-start.minutes));
-      }
+    String finalDuration = createDurationStringFromJavaTimeParts(p, d);
+
+    if("P".equals(finalDuration)) {
+      throw new GedcomxDateException("The start and end are equal yielding no duration.");
     }
 
-    if(end.hours != null) {
-      while(end.hours-start.hours < 0) {
-        end.day -= 1;
-        end.hours += 24;
-      }
-      if(end.hours-start.hours > 0) {
-        hasTime = true;
-        duration.insert(0,'H').insert(0,String.format("%02d", end.hours-start.hours));
-      }
-    }
+    return new GedcomxDateDuration(finalDuration);
 
-    if(hasTime) {
-      duration.insert(0,'T');
-    }
+  }
 
-    if(end.day != null) {
-      while(end.day-start.day < 0) {
-        end.day += daysInMonth(end.month == 1 ? 12 : end.month - 1, end.year);
-        end.month -= 1;
-        if(end.month < 1) {
-          end.year -= 1;
-          end.month += 12;
-        }
+  private static String createDurationStringFromJavaTimeParts(Period p, Duration d) {
+    StringBuilder duration = new StringBuilder("P");
+    if(!p.isZero()){
+      if (p.getYears() > 0) {
+        duration.append(p.getYears()).append('Y');
       }
-      if(end.day-start.day > 0) {
-        duration.insert(0,'D').insert(0,String.format("%02d", end.day-start.day));
+      if (p.getMonths() > 0) {
+        duration.append(p.getMonths()).append('M');
+      }
+      if (p.getDays() > 0) {
+        duration.append(p.getDays()).append('D');
       }
     }
-
-    if(end.month != null) {
-      while(end.month-start.month < 0) {
-        end.year -= 1;
-        end.month += 12;
+    if(!d.isZero()) {
+      duration.append('T');
+      if (d.toHours() > 0) {
+        duration.append(d.toHours()).append('H');
       }
-      if(end.month-start.month > 0) {
-        duration.insert(0,'M').insert(0,String.format("%02d", end.month-start.month));
+      if (d.toMinutesPart() > 0) {
+        duration.append(d.toMinutesPart()).append('M');
+      }
+      if (d.toSecondsPart() > 0) {
+        duration.append(d.toSecondsPart()).append('S');
       }
     }
+    return duration.toString();
+  }
 
-    if(end.year-start.year > 0) {
-      duration.insert(0,'Y').insert(0,String.format("%04d", end.year-start.year));
+  private static LocalDateTime getMinLocalDateTime(GedcomxDateSimple startDate) {
+    return LocalDateTime.of(
+      isNull(startDate.getYear()) ? -9999 : startDate.getYear(),
+      isNull(startDate.getMonth()) ? 1 : startDate.getMonth(),
+      isNull(startDate.getDay()) ? 1 : startDate.getDay(),
+      isNull(startDate.getHours()) ? 0 : startDate.getHours(),
+      isNull(startDate.getMinutes()) ? 0 : startDate.getMinutes(),
+      isNull(startDate.getSeconds()) ? 0 : startDate.getSeconds());
+  }
+
+  private static LocalDateTime getMaxLocalDateTime(GedcomxDateSimple endDate) {
+
+    // pull these out to calculate the day as needed.
+    int endYear = isNull(endDate.getYear()) ? 9999 : endDate.getYear();
+    int endMonth = isNull(endDate.getMonth()) ? 12 : endDate.getMonth();
+
+    LocalDateTime end = LocalDateTime.of(
+      endYear,
+      endMonth,
+      isNull(endDate.getDay()) ? YearMonth.of(endYear, endMonth).lengthOfMonth() : endDate.getDay(),
+      isNull(endDate.getHours()) ? 23 : endDate.getHours(),
+      isNull(endDate.getMinutes()) ? 59 : endDate.getMinutes(),
+      isNull(endDate.getSeconds()) ? 59 : endDate.getSeconds());
+
+    // Add one second to the last second to trigger a roll up across the entire end time
+    // to cause the durations to come out as P1Y instead of P11M30D23H59M59S. (It is off by one second, but looks much better
+    // and preserves the previous behavior.)
+    //
+    if(end.getSecond()==59){
+      end = end.plusSeconds(1);
     }
-
-    String finalDuration = duration.toString();
-
-    if(end.year-start.year < 0 || duration.toString().isEmpty()) {
-      throw new GedcomxDateException("Start Date must be less than End Date");
-    }
-
-    return new GedcomxDateDuration("P"+finalDuration);
+    return end;
   }
 
   /**
@@ -173,12 +177,7 @@ public class GedcomxDateUtil {
     // start with the start date, LocalDateTimes, don't support null values
     // fill in the blanks with 0's and reset the empties when building the gedcomx date
     // to return
-    LocalDateTime endLocalDateTime = LocalDateTime.of(
-      startDate.getYear(), isNull(startDate.getMonth()) ? 1 : startDate.getMonth(),
-        isNull(startDate.getDay()) ? 1 : startDate.getDay(),
-        isNull(startDate.getHours()) ? 0 : startDate.getHours(),
-        isNull(startDate.getMinutes()) ? 0 : startDate.getMinutes(),
-        isNull(startDate.getSeconds()) ? 0 : startDate.getSeconds())
+    LocalDateTime endLocalDateTime = getMinLocalDateTime(startDate)
       // apply the duration to get the end date.
       .plusSeconds(isNull(duration.getSeconds()) ? 0 : duration.getSeconds())
       .plusMinutes(isNull(duration.getMinutes()) ? 0 : duration.getMinutes())
@@ -192,7 +191,7 @@ public class GedcomxDateUtil {
     }
 
     return buildGedcomxDateFromLocalTimeDate(startDate, duration, endLocalDateTime);
-    }
+ }
 
     /**
      * Helper method to build an end GedcomxDateSimple from a GedcomxSimple, GedcomxDateDuration and LocalDateTime,
@@ -287,119 +286,14 @@ public class GedcomxDateUtil {
    * @param month The month
    * @param year The year
    * @return The number of days in the month
+   * @deprecated this method is just a pass through to java.time.YearMonth.lengthOfMonth
    */
+  @Deprecated(forRemoval = true)
   public static int daysInMonth(Integer month, Integer year) {
-    switch(month) {
-      case 1:
-      case 3:
-      case 5:
-      case 7:
-      case 8:
-      case 10:
-      case 12:
-        return 31;
-      case 4:
-      case 6:
-      case 9:
-      case 11:
-        return 30;
-      case 2:
-        boolean leapYear;
-        if(year % 4 != 0) {
-          leapYear = false;
-        } else if(year % 100 != 0) {
-          leapYear = true;
-        } else
-          leapYear = year % 400 == 0;
-        if(leapYear) {
-          return 29;
-        } else {
-          return 28;
-        }
-      default:
-        throw new GedcomxDateException("Unknown Month=" + month);
-    }
-  }
-
-  /**
-   * Ensures that both start and end have values where the other has values.
-   * For example, if start has minutes but end does not, this function
-   * will initialize minutes in end.
-   * @param start The start date
-   * @param end The end date
-   */
-  protected static void zipDates(Date start, Date end) {
-    if(start.month == null && end.month != null) {
-      start.month = 1;
-    }
-    if(start.month != null && end.month == null) {
-      end.month = 12;
-    }
-
-    if(start.day == null && end.day != null) {
-      start.day = 1;
-    }
-    if(start.day != null && end.day == null) {
-      if(end.month != null && end.year !=null ) {
-        end.day = daysInMonth(start.month, start.year);
-      } else {
-        end.day = start.day;
-      }
-    }
-
-    if(start.hours == null && end.hours != null) {
-      start.hours = 0;
-    }
-    if(start.hours != null && end.hours == null) {
-      end.hours = 23;
-    }
-
-    if(start.minutes == null && end.minutes != null) {
-      start.minutes = 0;
-    }
-    if(start.minutes != null && end.minutes == null) {
-      end.minutes = 59;
-    }
-
-    if(start.seconds == null && end.seconds != null) {
-      start.seconds = 0;
-    }
-    if(start.seconds != null && end.seconds == null) {
-      end.seconds = 59;
-    }
-  }
-
-  /**
-   * A simplified representation of a date.
-   * Used as a bag-o-properties when performing caluclations
-   */
-  protected static class Date {
-    public Integer year = null;
-    public Integer month = null;
-    public Integer day = null;
-    public Integer hours = null;
-    public Integer minutes = null;
-    public Integer seconds = null;
-
-    public Date() {}
-
-    public Date(GedcomxDateSimple simple, boolean adjustTimezone) {
-      year = simple.getYear();
-      month = simple.getMonth();
-      day = simple.getDay();
-      hours = simple.getHours();
-      minutes = simple.getMinutes();
-      seconds = simple.getSeconds();
-
-      if(adjustTimezone) {
-        if(hours != null && simple.getTzHours() != null) {
-          hours += simple.getTzHours();
-        }
-
-        if(minutes != null && simple.getTzMinutes() != null) {
-          minutes += simple.getTzMinutes();
-        }
-      }
+    try {
+      return YearMonth.of(year, month).lengthOfMonth();
+    } catch (DateTimeException e) {
+      throw new GedcomxDateException(e.getMessage(), e);
     }
   }
 

--- a/gedcomx-date/src/test/java/org/gedcomx/date/RangeTest.java
+++ b/gedcomx-date/src/test/java/org/gedcomx/date/RangeTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 /**
  * @author John Clark.
  */
-public class RangeTest {
+class RangeTest {
 
   @Test
   public void errorOnBlankString() {
@@ -150,7 +150,8 @@ public class RangeTest {
 
     assertThat(duration.getYears()).isEqualTo(1000);
     assertThat(duration.getMonths()).isEqualTo(9);
-    assertThat(duration.getDays()).isEqualTo(null);
+    // The entire day of 10-1 is included in the range
+    assertThat(duration.getDays()).isEqualTo(1);
     assertThat(duration.getHours()).isEqualTo(null);
     assertThat(duration.getMinutes()).isEqualTo(null);
     assertThat(duration.getSeconds()).isEqualTo(null);

--- a/gedcomx-date/src/test/java/org/gedcomx/date/UtilTest.java
+++ b/gedcomx-date/src/test/java/org/gedcomx/date/UtilTest.java
@@ -582,6 +582,7 @@ class UtilTest {
       Arguments.of("+1000/P1M1D", GedcomxDateType.RANGE, "+1000/+1000-02-01"),
       // All of 1000 and all of 1001
       Arguments.of("+1000/P2Y", GedcomxDateType.RANGE, "+1000/+1001"),
+      Arguments.of("A+1000/P1Y", GedcomxDateType.RANGE, "A+1000/+1000"),
       Arguments.of("/+1000", GedcomxDateType.RANGE, "/+1000"),
       Arguments.of("+1000/", GedcomxDateType.RANGE, "+1000/")
     );

--- a/gedcomx-date/src/test/java/org/gedcomx/date/UtilTest.java
+++ b/gedcomx-date/src/test/java/org/gedcomx/date/UtilTest.java
@@ -12,12 +12,12 @@ import java.util.stream.Stream;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author John Clark.
  */
-public class UtilTest {
+class UtilTest {
 
   /**
    * Parse
@@ -57,7 +57,8 @@ public class UtilTest {
 
     assertThat(date).isInstanceOf(GedcomxDateRange.class);
     assertThat(date.getType()).isEqualTo(GedcomxDateType.RANGE);
-    assertThat(((GedcomxDateRange)date).getDuration().getDays()).isEqualTo(1);
+    // All of the 31st and all of the 1st
+    assertThat(((GedcomxDateRange)date).getDuration().getDays()).isEqualTo(2);
   }
 
   @Test
@@ -77,9 +78,13 @@ public class UtilTest {
   }
 
   static Stream<Arguments> dropGranularityForMonth() {
-    return Stream.of(Arguments.of("+1788-07/P5M", "+1788-07/+1788"),
-                     Arguments.of("+1788-07-07/P24D", "+1788-07-07/+1788-07"),
-                     Arguments.of("+1788-07-07/P5M24D", "+1788-07-07/+1788"));
+    return Stream.of(
+      // All of July->All of December = 6M
+      Arguments.of("+1788-07/P6M", "+1788-07/+1788"),
+      // July 22th->July 31st = 10D counting the 22nd and the 31st
+      Arguments.of("+1788-07-22/P10D", "+1788-07-22/+1788-07"),
+      // July 22th 1788 -> All of December = 10D counting the 22nd and the 31st and the 5 remaining months
+      Arguments.of("+1788-07-22/P5M10D", "+1788-07-22/+1788"));
   }
 
   @ParameterizedTest
@@ -223,12 +228,13 @@ public class UtilTest {
             new GedcomxDateSimple("+0999-01-01T00:00:00Z"),
             new GedcomxDateSimple("+1000"));
 
-    assertThat(duration.getYears()).isEqualTo(1);
-    assertThat(duration.getMonths()).isEqualTo(11);
-    assertThat(duration.getDays()).isEqualTo(30);
-    assertThat(duration.getHours()).isEqualTo(23);
-    assertThat(duration.getMinutes()).isEqualTo(59);
-    assertThat(duration.getSeconds()).isEqualTo(59);
+    // this is now consistent with the formalString being 2Y
+    assertEquals(2,duration.getYears());
+    assertNull(duration.getMonths());
+    assertNull(duration.getDays());
+    assertNull(duration.getHours());
+    assertNull(duration.getMinutes());
+    assertNull(duration.getSeconds());
   }
 
   @Test
@@ -237,12 +243,13 @@ public class UtilTest {
             new GedcomxDateSimple("+0999"),
             new GedcomxDateSimple("+1000-01-01T00:00:00Z"));
 
-    assertThat(duration.getYears()).isEqualTo(1);
-    assertThat(duration.getMonths()).isEqualTo(null);
-    assertThat(duration.getDays()).isEqualTo(null);
-    assertThat(duration.getHours()).isEqualTo(null);
-    assertThat(duration.getMinutes()).isEqualTo(null);
-    assertThat(duration.getSeconds()).isEqualTo(null);
+    // this is now consistent with the formalString being 1Y
+    assertEquals(1, duration.getYears());
+    assertNull(duration.getMonths());
+    assertNull(duration.getDays());
+    assertNull(duration.getHours());
+    assertNull(duration.getMinutes());
+    assertNull(duration.getSeconds());
   }
 
   @Test
@@ -253,7 +260,8 @@ public class UtilTest {
 
     assertThat(duration.getYears()).isEqualTo(3);
     assertThat(duration.getMonths()).isEqualTo(null);
-    assertThat(duration.getDays()).isEqualTo(1);
+    // All of the 31st and all of the 1st.
+    assertThat(duration.getDays()).isEqualTo(2);
     assertThat(duration.getHours()).isEqualTo(null);
     assertThat(duration.getMinutes()).isEqualTo(null);
     assertThat(duration.getSeconds()).isEqualTo(null);
@@ -491,141 +499,8 @@ public class UtilTest {
       GedcomxDateUtil.daysInMonth(13, 2000);
       fail("GedcomxDateException expected because 13 is not a month");
     } catch(GedcomxDateException e) {
-      assertThat(e.getMessage()).isEqualTo("Unknown Month=13");
+      assertThat(e.getMessage()).isEqualTo("Invalid value for MonthOfYear (valid values 1 - 12): 13");
     }
-  }
-
-  @Test
-  public void successOnValidStuff() {
-
-    assertThat(GedcomxDateUtil.daysInMonth(1, 2001)).isEqualTo(31);
-    assertThat(GedcomxDateUtil.daysInMonth(2, 2001)).isEqualTo(28);
-    assertThat(GedcomxDateUtil.daysInMonth(3, 2001)).isEqualTo(31);
-    assertThat(GedcomxDateUtil.daysInMonth(4, 2001)).isEqualTo(30);
-    assertThat(GedcomxDateUtil.daysInMonth(5, 2001)).isEqualTo(31);
-    assertThat(GedcomxDateUtil.daysInMonth(6, 2001)).isEqualTo(30);
-    assertThat(GedcomxDateUtil.daysInMonth(7, 2001)).isEqualTo(31);
-    assertThat(GedcomxDateUtil.daysInMonth(8, 2001)).isEqualTo(31);
-    assertThat(GedcomxDateUtil.daysInMonth(9, 2001)).isEqualTo(30);
-    assertThat(GedcomxDateUtil.daysInMonth(10, 2001)).isEqualTo(31);
-    assertThat(GedcomxDateUtil.daysInMonth(11, 2001)).isEqualTo(30);
-    assertThat(GedcomxDateUtil.daysInMonth(12, 2001)).isEqualTo(31);
-
-    // Test each branch of the leapyear calculation
-    assertThat(GedcomxDateUtil.daysInMonth(2, 2003)).isEqualTo(28);
-    assertThat(GedcomxDateUtil.daysInMonth(2, 2004)).isEqualTo(29);
-    assertThat(GedcomxDateUtil.daysInMonth(2, 1900)).isEqualTo(28);
-    assertThat(GedcomxDateUtil.daysInMonth(2, 2000)).isEqualTo(29);
-  }
-
-  @Test
-  public void successOnZipStartMonth() {
-    GedcomxDateUtil.Date start = new GedcomxDateUtil.Date();
-    GedcomxDateUtil.Date end = new GedcomxDateUtil.Date();
-    start.month = 5;
-
-    GedcomxDateUtil.zipDates(start, end);
-
-    assertThat(end.month).isEqualTo(12);
-  }
-
-  @Test
-  public void successOnZipEndMonth() {
-    GedcomxDateUtil.Date start = new GedcomxDateUtil.Date();
-    GedcomxDateUtil.Date end = new GedcomxDateUtil.Date();
-    end.month = 5;
-
-    GedcomxDateUtil.zipDates(start, end);
-
-    assertThat(start.month).isEqualTo(1);
-  }
-
-  @Test
-  public void successOnZipStartDay() {
-    GedcomxDateUtil.Date start = new GedcomxDateUtil.Date();
-    GedcomxDateUtil.Date end = new GedcomxDateUtil.Date();
-    start.day = 5;
-
-    GedcomxDateUtil.zipDates(start, end);
-
-    assertThat(end.day).isEqualTo(5);
-  }
-
-  @Test
-  public void successOnZipEndDay() {
-    GedcomxDateUtil.Date start = new GedcomxDateUtil.Date();
-    GedcomxDateUtil.Date end = new GedcomxDateUtil.Date();
-    end.day = 5;
-
-    GedcomxDateUtil.zipDates(start, end);
-
-    assertThat(start.day).isEqualTo(1);
-  }
-
-  @Test
-  public void successOnZipStartHour() {
-    GedcomxDateUtil.Date start = new GedcomxDateUtil.Date();
-    GedcomxDateUtil.Date end = new GedcomxDateUtil.Date();
-    start.hours = 5;
-
-    GedcomxDateUtil.zipDates(start, end);
-
-    assertThat(end.hours).isEqualTo(23);
-  }
-
-  @Test
-  public void successOnZipEndHour() {
-    GedcomxDateUtil.Date start = new GedcomxDateUtil.Date();
-    GedcomxDateUtil.Date end = new GedcomxDateUtil.Date();
-    end.hours = 5;
-
-    GedcomxDateUtil.zipDates(start, end);
-
-    assertThat(start.hours).isEqualTo(0);
-  }
-
-  @Test
-  public void successOnZipStartMinute() {
-    GedcomxDateUtil.Date start = new GedcomxDateUtil.Date();
-    GedcomxDateUtil.Date end = new GedcomxDateUtil.Date();
-    start.minutes = 5;
-
-    GedcomxDateUtil.zipDates(start, end);
-
-    assertThat(end.minutes).isEqualTo(59);
-  }
-
-  @Test
-  public void successOnZipEndMinute() {
-    GedcomxDateUtil.Date start = new GedcomxDateUtil.Date();
-    GedcomxDateUtil.Date end = new GedcomxDateUtil.Date();
-    end.minutes = 5;
-
-    GedcomxDateUtil.zipDates(start, end);
-
-    assertThat(start.minutes).isEqualTo(0);
-  }
-
-  @Test
-  public void successOnZipStartSecond() {
-    GedcomxDateUtil.Date start = new GedcomxDateUtil.Date();
-    GedcomxDateUtil.Date end = new GedcomxDateUtil.Date();
-    start.seconds = 5;
-
-    GedcomxDateUtil.zipDates(start, end);
-
-    assertThat(end.seconds).isEqualTo(59);
-  }
-
-  @Test
-  public void successOnZipEndSecond() {
-    GedcomxDateUtil.Date start = new GedcomxDateUtil.Date();
-    GedcomxDateUtil.Date end = new GedcomxDateUtil.Date();
-    end.seconds = 5;
-
-    GedcomxDateUtil.zipDates(start, end);
-
-    assertThat(start.seconds).isEqualTo(0);
   }
 
   @Test
@@ -696,5 +571,28 @@ public class UtilTest {
   public void testParsingZeroYear() {
     String yearZero = "+0000";
     Assertions.assertThatNoException().isThrownBy(() -> GedcomxDateUtil.parse(yearZero));
+  }
+
+  static Stream<Arguments> testEqualStartAndEndDate(){
+    return Stream.of(
+      Arguments.of("+1000/P1Y", GedcomxDateType.RANGE, "+1000/+1000"),
+      Arguments.of("+1000-01-01/P1D", GedcomxDateType.RANGE, "+1000-01-01/+1000-01-01"),
+      Arguments.of("+1000-01-01/P1Y", GedcomxDateType.RANGE, "+1000-01-01/+1000"),
+      // All of January, and All of Feb 1.
+      Arguments.of("+1000/P1M1D", GedcomxDateType.RANGE, "+1000/+1000-02-01"),
+      // All of 1000 and all of 1001
+      Arguments.of("+1000/P2Y", GedcomxDateType.RANGE, "+1000/+1001"),
+      Arguments.of("/+1000", GedcomxDateType.RANGE, "/+1000"),
+      Arguments.of("+1000/", GedcomxDateType.RANGE, "+1000/")
+    );
+
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testEqualStartAndEndDate(String expectString, GedcomxDateType expectedType, String input){
+    GedcomxDate result = assertDoesNotThrow(()->GedcomxDateUtil.parse(input));
+    assertEquals(expectString, result.toFormalString());
+    assertEquals(expectedType, result.getType() );
   }
 }


### PR DESCRIPTION
For closed ranges:
Treat the unspecified portions of the start date as minimum values . Treat the unspecified portions of the end date as maximum values.

If the second in the range end date is 59, then add one second to the end date.

The additional second causes the end range to be inclusive and allows the ranges to print cleanly.

This adds the ability to parse range date string of: "+YYYY/+YYYY" where both years are equal.

Equal start and end values that are completely specified down to the second are still invalid as there is no time between the start and end.