### PR TITLE
Revert commit bd18e6df: "Add `equals` and `hashCode` methods for comparing `SourceDescription` objects"

### DIFF
--- a/gedcomx-model/src/main/java/org/gedcomx/common/Attribution.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/Attribution.java
@@ -26,7 +26,6 @@ import org.gedcomx.rt.json.JsonElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
 import java.util.Date;
-import java.util.Objects;
 
 
 /**
@@ -310,27 +309,5 @@ public class Attribution extends ExtensibleData {
   @Override
   public String toString() {
     return (contributor == null) ? "" : contributor.toString();
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final Attribution that = (Attribution) o;
-    return Objects.equals(changeMessage, that.changeMessage) &&
-           Objects.equals(changeMessageResource, that.changeMessageResource) &&
-           Objects.equals(contributor, that.contributor) &&
-           Objects.equals(created, that.created) &&
-           Objects.equals(creator, that.creator) &&
-           Objects.equals(modified, that.modified);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(changeMessage, changeMessageResource, contributor, created, creator, modified);
   }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/common/ResourceReference.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/ResourceReference.java
@@ -21,12 +21,11 @@ import com.webcohesion.enunciate.metadata.Facets;
 import org.gedcomx.rt.GedcomxConstants;
 import org.gedcomx.rt.json.JsonElementWrapper;
 
+import javax.xml.XMLConstants;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
-import javax.xml.XMLConstants;
-import java.util.Objects;
 
 /**
  * A generic reference to a resource.
@@ -138,23 +137,5 @@ public final class ResourceReference {
   @Override
   public String toString() {
     return (resource == null) ? "" : resource.toString();
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final ResourceReference that = (ResourceReference) o;
-    return Objects.equals(resource, that.resource) &&
-           Objects.equals(resourceId, that.resourceId);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(resource, resourceId);
   }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Date.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Date.java
@@ -39,7 +39,6 @@ import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -330,26 +329,5 @@ public class Date extends ExtensibleData implements HasFields {
    */
   public void accept(GedcomxModelVisitor visitor) {
     visitor.visitDate(this);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final Date that = (Date) o;
-    return Objects.equals(confidence, that.confidence) &&
-           Objects.equals(fields, that.fields) &&
-           Objects.equals(formal, that.formal) &&
-           Objects.equals(normalized, that.normalized) &&
-           Objects.equals(original, that.original);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(confidence, fields, formal, normalized, original);
   }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Identifier.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Identifier.java
@@ -28,7 +28,6 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
-import java.util.Objects;
 
 /**
  * An identifier for a resource.
@@ -200,22 +199,4 @@ public final class Identifier implements HasJsonKey {
     return (value == null) ? "" : value.toString();
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final Identifier that = (Identifier) o;
-    return hasUniqueKey == that.hasUniqueKey &&
-           Objects.equals(type, that.type) &&
-           Objects.equals(value, that.value);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(hasUniqueKey, type, value);
-  }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDescription.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDescription.java
@@ -32,7 +32,6 @@ import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 
@@ -520,30 +519,5 @@ public class PlaceDescription extends Subject {
       this.display.embed(place.display);
     }
     super.embed(place);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final PlaceDescription that = (PlaceDescription) o;
-    return Objects.equals(display, that.display) &&
-           Objects.equals(jurisdiction, that.jurisdiction) &&
-           Objects.equals(latitude, that.latitude) &&
-           Objects.equals(longitude, that.longitude) &&
-           Objects.equals(names, that.names) &&
-           Objects.equals(place, that.place) &&
-           Objects.equals(spatialDescription, that.spatialDescription) &&
-           Objects.equals(temporalDescription, that.temporalDescription) &&
-           Objects.equals(type, that.type);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(display, jurisdiction, latitude, longitude, names, place, spatialDescription, temporalDescription, type);
   }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDisplayProperties.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDisplayProperties.java
@@ -21,7 +21,6 @@ import org.gedcomx.common.ExtensibleData;
 import org.gedcomx.rt.GedcomxConstants;
 
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.Objects;
 
 
 /**
@@ -155,24 +154,5 @@ public class PlaceDisplayProperties extends ExtensibleData {
     this.fullName = this.fullName == null ? data.fullName : this.fullName;
     this.type = this.type == null ? data.type : this.type;
     super.embed(data);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final PlaceDisplayProperties that = (PlaceDisplayProperties) o;
-    return Objects.equals(fullName, that.fullName) &&
-           Objects.equals(name, that.name) &&
-           Objects.equals(type, that.type);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(fullName, name, type);
   }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceReference.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceReference.java
@@ -38,7 +38,6 @@ import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 
@@ -322,26 +321,5 @@ public class PlaceReference extends ExtensibleData implements HasFields {
    */
   public void accept(GedcomxModelVisitor visitor) {
     visitor.visitPlaceReference(this);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final PlaceReference that = (PlaceReference) o;
-    return Objects.equals(confidence, that.confidence) &&
-           Objects.equals(descriptionRef, that.descriptionRef) &&
-           Objects.equals(fields, that.fields) &&
-           Objects.equals(normalized, that.normalized) &&
-           Objects.equals(original, that.original);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(confidence, descriptionRef, fields, normalized, original);
   }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/records/Field.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/Field.java
@@ -36,7 +36,6 @@ import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -214,23 +213,5 @@ public class Field extends Conclusion {
     }
 
     return "";
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final Field that = (Field) o;
-    return Objects.equals(type, that.type) &&
-           Objects.equals(values, that.values);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(type, values);
   }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/records/FieldValue.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/FieldValue.java
@@ -36,7 +36,6 @@ import org.gedcomx.types.FieldValueType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.Objects;
 
 
 /**
@@ -387,27 +386,5 @@ public final class FieldValue extends Conclusion {
   @Override
   public String toString() {
     return labelId + ": " + text;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final FieldValue that = (FieldValue) o;
-    return Objects.equals(datatype, that.datatype) &&
-           Objects.equals(labelId, that.labelId) &&
-           Objects.equals(resource, that.resource) &&
-           Objects.equals(status, that.status) &&
-           Objects.equals(text, that.text) &&
-           Objects.equals(type, that.type);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(datatype, labelId, resource, status, text, type);
   }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/source/Coverage.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/Coverage.java
@@ -30,7 +30,6 @@ import org.gedcomx.types.RecordType;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.Objects;
 
 /**
  * A description of the coverage of a resource.
@@ -180,22 +179,4 @@ public class Coverage extends HypermediaEnabledData {
     setRecordType(type == null ? null : type.toQNameURI());
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final Coverage that = (Coverage) o;
-    return Objects.equals(recordType, that.recordType) &&
-           Objects.equals(spatial, that.spatial) &&
-           Objects.equals(temporal, that.temporal);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(recordType, spatial, temporal);
-  }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/source/SourceDescription.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/SourceDescription.java
@@ -15,6 +15,20 @@
  */
 package org.gedcomx.source;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.xml.XMLConstants;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -23,7 +37,13 @@ import com.webcohesion.enunciate.metadata.Facets;
 import com.webcohesion.enunciate.metadata.qname.XmlQNameEnumRef;
 import com.webcohesion.enunciate.metadata.rs.TypeHint;
 import org.gedcomx.agent.Agent;
-import org.gedcomx.common.*;
+import org.gedcomx.common.Attributable;
+import org.gedcomx.common.Attribution;
+import org.gedcomx.common.HasNotes;
+import org.gedcomx.common.Note;
+import org.gedcomx.common.ResourceReference;
+import org.gedcomx.common.TextValue;
+import org.gedcomx.common.URI;
 import org.gedcomx.conclusion.Identifier;
 import org.gedcomx.links.HypermediaEnabledData;
 import org.gedcomx.links.Link;
@@ -37,9 +57,6 @@ import org.gedcomx.types.ResourceStatusType;
 import org.gedcomx.types.ResourceType;
 import org.gedcomx.util.JsonIdentifiers;
 
-import jakarta.xml.bind.annotation.*;
-import javax.xml.XMLConstants;
-import java.util.*;
 
 /**
  * Represents a description of a source.
@@ -1354,53 +1371,5 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
   @Override
   public String toString() {
     return getId() + ": " + this.resourceType;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final SourceDescription that = (SourceDescription) o;
-    return Objects.equals(about, that.about) &&
-           Objects.equals(analysis, that.analysis) &&
-           Objects.equals(attribution, that.attribution) &&
-           Objects.equals(authors, that.authors) &&
-           Objects.equals(citations, that.citations) &&
-           Objects.equals(componentOf, that.componentOf) &&
-           Objects.equals(coverage, that.coverage) &&
-           Objects.equals(created, that.created) &&
-           Objects.equals(descriptions, that.descriptions) &&
-           Objects.equals(descriptorRef, that.descriptorRef) &&
-           Objects.equals(fields, that.fields) &&
-           Objects.equals(identifiers, that.identifiers) &&
-           Objects.equals(lang, that.lang) &&
-           Objects.equals(mediaType, that.mediaType) &&
-           Objects.equals(mediator, that.mediator) &&
-           Objects.equals(modified, that.modified) &&
-           Objects.equals(notes, that.notes) &&
-           Objects.equals(publisher, that.publisher) &&
-           Objects.equals(replacedBy, that.replacedBy) &&
-           Objects.equals(replaces, that.replaces) &&
-           Objects.equals(repository, that.repository) &&
-           Objects.equals(resourceType, that.resourceType) &&
-           Objects.equals(rights, that.rights) &&
-           Objects.equals(sortKey, that.sortKey) &&
-           Objects.equals(sources, that.sources) &&
-           Objects.equals(statuses, that.statuses) &&
-           Objects.equals(titleLabel, that.titleLabel) &&
-           Objects.equals(titles, that.titles) &&
-           Objects.equals(version, that.version);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(about, analysis, attribution, authors, citations, componentOf, coverage, created, descriptions,
-                        descriptorRef, fields, identifiers, lang, mediaType, mediator, modified, notes, publisher,
-                        replacedBy, replaces, repository, resourceType, rights, sortKey, sources, statuses,
-                        titleLabel, titles, version);
   }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/source/SourceReference.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/SourceReference.java
@@ -32,7 +32,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 
@@ -249,25 +248,5 @@ public class SourceReference extends HypermediaEnabledData implements Attributab
    */
   public void accept(GedcomxModelVisitor visitor) {
     visitor.visitSourceReference(this);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final SourceReference that = (SourceReference) o;
-    return Objects.equals(attribution, that.attribution) &&
-           Objects.equals(descriptionId, that.descriptionId) &&
-           Objects.equals(descriptionRef, that.descriptionRef) &&
-           Objects.equals(qualifiers, that.qualifiers);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(attribution, descriptionId, descriptionRef, qualifiers);
   }
 }

--- a/gedcomx-model/src/test/java/org/gedcomx/source/SourceDescriptionTest.java
+++ b/gedcomx-model/src/test/java/org/gedcomx/source/SourceDescriptionTest.java
@@ -1,24 +1,14 @@
 package org.gedcomx.source;
 
-import org.gedcomx.common.*;
-import org.gedcomx.conclusion.Identifier;
-import org.gedcomx.conclusion.PlaceDescription;
-import org.gedcomx.conclusion.PlaceDisplayProperties;
-import org.gedcomx.conclusion.PlaceReference;
-import org.gedcomx.date.GedcomxDateSimple;
-import org.gedcomx.records.Field;
-import org.gedcomx.records.FieldValue;
-import org.gedcomx.rt.SerializationUtil;
-import org.gedcomx.types.ConfidenceLevel;
-import org.gedcomx.types.IdentifierType;
-import org.gedcomx.types.ResourceStatusType;
-import org.junit.jupiter.api.Test;
-
-import jakarta.xml.bind.JAXBException;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+
+import jakarta.xml.bind.JAXBException;
+
+import org.gedcomx.common.URI;
+import org.gedcomx.rt.SerializationUtil;
+import org.gedcomx.types.ResourceStatusType;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,26 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class SourceDescriptionTest {
 
-  private static final String TEST_STRING = "test";
-  private static final TextValue TEST_TEXT_VALUE = new TextValue(TEST_STRING).lang(TEST_STRING);
-  private static final URI TEST_URI = URI.create("http://test.test/");
-  private static final ResourceReference TEST_RESOURCE_REFERENCE = new ResourceReference(TEST_URI);
-  private static final Attribution TEST_ATTRIBUTION = new Attribution()
-    .contributor(TEST_RESOURCE_REFERENCE)
-    .creator(TEST_RESOURCE_REFERENCE)
-    .modified(new Date())
-    .created(new Date())
-    .changeMessage(TEST_STRING)
-    .changeMessageResource(TEST_URI);
-  private static final Qualifier TEST_QUALIFIER = new Qualifier(TEST_URI, TEST_STRING);
-  private static final SourceReference TEST_SOURCE_REFERENCE = new SourceReference()
-    .descriptionRef(TEST_URI)
-    .descriptionId(TEST_STRING)
-    .attribution(TEST_ATTRIBUTION)
-    .qualifier(TEST_QUALIFIER);
-  private static final Field TEST_FIELD = new Field()
-    .type(TEST_URI)
-    .value(new FieldValue(TEST_STRING));
 
   @Test
   public void testXml() throws JAXBException, UnsupportedEncodingException {
@@ -92,73 +62,4 @@ public class SourceDescriptionTest {
     assertThat(ref).isSameAs(sd);
   }
 
-  @Test
-  public void equals() {
-    final Date date = new Date();
-    final SourceDescription sd1 = buildFullSourceDescription(date);
-    final SourceDescription sd2 = buildFullSourceDescription(date);
-    assertThat(sd1).isEqualTo(sd2);
-  }
-
-  private SourceDescription buildFullSourceDescription(Date date) {
-    final org.gedcomx.conclusion.Date testDate = new org.gedcomx.conclusion.Date()
-      .confidence(ConfidenceLevel.High)
-      .field(new Field())
-      .formal(new GedcomxDateSimple("+1970"))
-      .original(TEST_STRING);
-    testDate.setNormalizedExtensions(List.of(TEST_TEXT_VALUE));
-
-    final SourceDescription sd = new SourceDescription()
-      .lang(TEST_STRING)
-      .citation(TEST_STRING)
-      .mediaType(TEST_STRING)
-      .about(TEST_URI)
-      .mediator(TEST_RESOURCE_REFERENCE)
-      .publisher(TEST_RESOURCE_REFERENCE)
-      .authors(TEST_URI)
-      .source(TEST_SOURCE_REFERENCE)
-      .analysis(TEST_RESOURCE_REFERENCE)
-      .componentOf(TEST_SOURCE_REFERENCE)
-      .title(TEST_TEXT_VALUE)
-      .titleLabel(TEST_TEXT_VALUE)
-      .note(new Note()
-              .id(TEST_STRING)
-              .lang(TEST_STRING)
-              .subject(TEST_STRING)
-              .text(TEST_STRING)
-              .attribution(TEST_ATTRIBUTION))
-      .attribution(TEST_ATTRIBUTION)
-      .resourceType(TEST_URI)
-      .rights(TEST_URI)
-      .sortKey(TEST_STRING)
-      .description(TEST_TEXT_VALUE)
-      .identifier(new Identifier(TEST_URI, IdentifierType.Primary))
-      .created(date)
-      .modified(date)
-      .coverage(new Coverage()
-                  .spatial(new PlaceReference()
-                             .original(TEST_STRING)
-                             .description(new PlaceDescription()
-                                            .name(TEST_TEXT_VALUE)
-                                            .type(TEST_URI)
-                                            .temporalDescription(testDate)
-                                            .latitude(35.0)
-                                            .longitude(-35.0)
-                                            .place(TEST_RESOURCE_REFERENCE)
-                                            .spatialDescription(TEST_RESOURCE_REFERENCE)
-                                            .jurisdiction(TEST_RESOURCE_REFERENCE)
-                                            .displayExtension(new PlaceDisplayProperties()
-                                                                .name(TEST_STRING)
-                                                                .fullName(TEST_STRING)
-                                                                .type(TEST_STRING))))
-                  .temporal(testDate)
-                  .recordType(TEST_URI))
-      .field(TEST_FIELD)
-      .repository(TEST_RESOURCE_REFERENCE)
-      .descriptorRef(TEST_RESOURCE_REFERENCE)
-      .version(TEST_STRING);
-    sd.setReplaces(List.of(TEST_URI));
-    sd.setReplacedBy(TEST_URI);
-    return sd;
-  }
 }


### PR DESCRIPTION
This reverts adding equals/hashCode to model objects. I would normally insist on the proper implementation of these methods; however, these changes have caused errors in existing code. There needs to be further consideration of what equality actually means for these classes, and not merely "every single field must be equal". 

This does NOT remove implementations that existed prior to [3.10.0](https://github.com/FamilySearch/gedcomx-java/releases/tag/3.10.0). They include: 

- `Note`
- `Qualifier`
- `SourceCitation`
- `TextValue`
- `URI`