### PR TITLE
Add Swagger Jakarta annotations dependency to POM files

### DIFF
--- a/extensions/familysearch/familysearch-api-model/pom.xml
+++ b/extensions/familysearch/familysearch-api-model/pom.xml
@@ -24,5 +24,10 @@
       <artifactId>gedcomx-atom</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations-jakarta</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/gedcomx-model/pom.xml
+++ b/gedcomx-model/pom.xml
@@ -54,6 +54,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations-jakarta</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.gedcomx</groupId>
       <artifactId>gedcomx-test-support</artifactId>
       <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     <pgp-maven-plugin.version>1.1</pgp-maven-plugin.version>
+    <swagger-core.version>2.2.27</swagger-core.version>
   </properties>
 
   <modules>
@@ -123,6 +124,7 @@
         <artifactId>jakarta.ws.rs-api</artifactId>
         <version>${jakarta.ws.rs-api.version}</version>
       </dependency>
+
       <dependency>
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
@@ -146,21 +148,30 @@
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
       </dependency>
+
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
         <version>${junit-jupiter.version}</version>
       </dependency>
+
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj.version}</version>
       </dependency>
+
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-core</artifactId>
         <version>${hamcrest.version}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-annotations-jakarta</artifactId>
+        <version>${swagger-core.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Integrated the `swagger-annotations-jakarta` dependency into multiple POM files to support Jakarta annotations. Updated the `swagger-core.version` property in the root POM for version consistency across modules.