### PR TITLE
Gedcomx schema updates for OpenAPI 

### DIFF
--- a/gedcomx-model/src/main/java/org/gedcomx/Gedcomx.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/Gedcomx.java
@@ -43,6 +43,8 @@ import org.gedcomx.types.RelationshipType;
 import org.gedcomx.types.ResourceType;
 
 import javax.xml.XMLConstants;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.*;
 import java.text.DateFormat;
 import java.util.ArrayList;
@@ -90,20 +92,54 @@ import java.util.stream.Stream;
 @JsonElementWrapper ( name = "gedcomx" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
 @XmlType ( name = "Gedcomx", propOrder = {"attribution", "persons", "relationships", "sourceDescriptions", "agents", "events", "places", "documents", "collections", "fields", "recordDescriptors"} )
+@Schema(name = "The GEDCOM X data formats define the serialization formats of the GEDCOM X conceptual model. The canonical documentation is provided by the formal specification documents:\n" +
+    "\n" +
+    "*   [The GEDCOM X Conceptual Model, Version 1.0](https://github.com/FamilySearch/gedcomx/blob/master/specifications/conceptual-model-specification.md)\n" +
+    "*   [The GEDCOM X JSON Format, Version 1.0](https://github.com/FamilySearch/gedcomx/blob/master/specifications/json-format-specification.md)\n" +
+    "*   [The GEDCOM X XML Format, Version 1.0](https://github.com/FamilySearch/gedcomx/blob/master/specifications/xml-format-specification.md)")
 public class Gedcomx extends HypermediaEnabledData implements HasFields {
 
+  @Schema(description = "The language of this genealogical data set. See http://www.w3.org/International/articles/language-tags/. " +
+      "Note that some language-enabled elements MAY override the language.")
   private String lang;
+
+  @Schema(description = "A reference to a description of this data set.")
   private URI descriptionRef;
+
+  @Schema(description = "The attribution of this genealogical data.")
   private Attribution attribution;
+
+  @Schema(description = "The persons included in this genealogical data set.")
   private List<Person> persons;
+
+  @Schema(description = "The relationships included in this genealogical data set.")
   private List<Relationship> relationships;
+
+  @Schema(description = "The descriptions of sources included in this genealogical data set.")
   private List<SourceDescription> sourceDescriptions;
+
+  @Schema(description = "The agents included in this genealogical data set.")
   private List<Agent> agents;
+
+  @Schema(description = "The events included in this genealogical data set.")
   private List<Event> events;
+
+  @Schema(description = "The places included in this genealogical data set.")
   private List<PlaceDescription> places;
+
+  @Schema(description = "The documents included in this genealogical data set.")
   private List<Document> documents;
+
+  @Schema(description = "The collections included in this genealogical data set.")
   private List<Collection> collections;
+
+  @Schema(description = "The extracted fields included in this genealogical data set.  Fields that apply to a particular person,\n" +
+      " * relationship or value should be included within that person or value, respectively.\n" +
+      " * Remaining fields that did not have a place within the person or relationship structure can be included here.\n" +
+      " * Also, fields that were extracted but not yet fit into a structure can also be included here.")
   private List<Field> fields;
+
+  @Schema(description = "The record descriptors included in this genealogical data set.")
   private List<RecordDescriptor> recordDescriptors;
 
   public Gedcomx() {

--- a/gedcomx-model/src/main/java/org/gedcomx/Gedcomx.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/Gedcomx.java
@@ -92,11 +92,11 @@ import java.util.stream.Stream;
 @JsonElementWrapper ( name = "gedcomx" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
 @XmlType ( name = "Gedcomx", propOrder = {"attribution", "persons", "relationships", "sourceDescriptions", "agents", "events", "places", "documents", "collections", "fields", "recordDescriptors"} )
-@Schema(name = "The GEDCOM X data formats define the serialization formats of the GEDCOM X conceptual model. The canonical documentation is provided by the formal specification documents:\n" +
-    "\n" +
-    "*   [The GEDCOM X Conceptual Model, Version 1.0](https://github.com/FamilySearch/gedcomx/blob/master/specifications/conceptual-model-specification.md)\n" +
-    "*   [The GEDCOM X JSON Format, Version 1.0](https://github.com/FamilySearch/gedcomx/blob/master/specifications/json-format-specification.md)\n" +
-    "*   [The GEDCOM X XML Format, Version 1.0](https://github.com/FamilySearch/gedcomx/blob/master/specifications/xml-format-specification.md)")
+@Schema(name = "The GEDCOM X data formats define the serialization formats of the GEDCOM X conceptual model. The canonical documentation is provided by the formal specification documents:" +
+    " [The GEDCOM X Conceptual Model, Version 1.0](https://github.com/FamilySearch/gedcomx/blob/master/specifications/conceptual-model-specification.md)" +
+    " [The GEDCOM X JSON Format, Version 1.0](https://github.com/FamilySearch/gedcomx/blob/master/specifications/json-format-specification.md)" +
+    " [The GEDCOM X XML Format, Version 1.0](https://github.com/FamilySearch/gedcomx/blob/master/specifications/xml-format-specification.md)" +
+    "This documentation is provided as a non-normative reference guide.")
 public class Gedcomx extends HypermediaEnabledData implements HasFields {
 
   @Schema(description = "The language of this genealogical data set. See http://www.w3.org/International/articles/language-tags/. " +
@@ -133,10 +133,6 @@ public class Gedcomx extends HypermediaEnabledData implements HasFields {
   @Schema(description = "The collections included in this genealogical data set.")
   private List<Collection> collections;
 
-  @Schema(description = "The extracted fields included in this genealogical data set.  Fields that apply to a particular person,\n" +
-      " * relationship or value should be included within that person or value, respectively.\n" +
-      " * Remaining fields that did not have a place within the person or relationship structure can be included here.\n" +
-      " * Also, fields that were extracted but not yet fit into a structure can also be included here.")
   private List<Field> fields;
 
   @Schema(description = "The record descriptors included in this genealogical data set.")

--- a/gedcomx-model/src/main/java/org/gedcomx/agent/Address.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/agent/Address.java
@@ -15,6 +15,8 @@
  */
 package org.gedcomx.agent;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import org.gedcomx.common.ExtensibleData;
 
 import jakarta.xml.bind.annotation.XmlType;
@@ -26,18 +28,40 @@ import jakarta.xml.bind.annotation.XmlType;
  * @author Ryan Heaton
  */
 @XmlType ( name = "Address" )
+@Schema(description = "An address.")
 public class Address extends ExtensibleData {
 
+  @Schema(description = "The city.")
   private String city;
+
+  @Schema(description = "The country.")
   private String country;
+
+  @Schema(description = "The postal code.")
   private String postalCode;
+
+  @Schema(description = "The state or province.")
   private String stateOrProvince;
+
+  @Schema(description = "The street.")
   private String street;
+
+  @Schema(description = "Additional street information.")
   private String street2;
+
+  @Schema(description = "Additional street information.")
   private String street3;
+
+  @Schema(description = "Additional street information.")
   private String street4;
+
+  @Schema(description = "Additional street information.")
   private String street5;
+
+  @Schema(description = "Additional street information.")
   private String street6;
+
+  @Schema(description = "The value of the property, if it can be expressed as a string.")
   private String value;
 
   public Address() {

--- a/gedcomx-model/src/main/java/org/gedcomx/agent/Address.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/agent/Address.java
@@ -28,7 +28,7 @@ import jakarta.xml.bind.annotation.XmlType;
  * @author Ryan Heaton
  */
 @XmlType ( name = "Address" )
-@Schema(description = "An address.")
+@Schema(description = "An Address.")
 public class Address extends ExtensibleData {
 
   @Schema(description = "The city.")

--- a/gedcomx-model/src/main/java/org/gedcomx/agent/Agent.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/agent/Agent.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.webcohesion.enunciate.metadata.rs.TypeHint;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.gedcomx.common.ResourceReference;
 import org.gedcomx.common.TextValue;
 import org.gedcomx.common.URI;
@@ -34,7 +35,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 
-import java.sql.Array;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,16 +50,35 @@ import java.util.List;
 @XmlType ( name = "Agent" )
 @JsonElementWrapper ( name = "agents" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "An agent, e.g. person, organization, or group. In genealogical research, an agent often takes the role of a contributor." +
+    "\n@see [foaf:Agent](http://xmlns.com/foaf/spec/#term_Agent)")
 public class Agent extends HypermediaEnabledData {
 
+  @Schema(description = "The list of names for the agent.")
   private List<TextValue> names;
+
+  @Schema(description = "The list of identifiers for the agent.")
   private List<Identifier> identifiers;
+
+  @Schema(description = "The homepage of the person or organization. Note this is different from the homepage of the service where the person or organization has an account.")
   private ResourceReference homepage;
+
+  @Schema(description = "The openid of the person or organization.")
   private ResourceReference openid;
+
+  @Schema(description = "The accounts that belong to this person or organization.")
   private List<OnlineAccount> accounts;
+
+  @Schema(description = "The emails that belong to this person or organization.")
   private List<ResourceReference> emails;
+
+  @Schema(description = "The phones that belong to this person or organization.")
   private List<ResourceReference> phones;
+
+  @Schema(description = "The addresses that belong to this person or organization.")
   private List<Address> addresses;
+
+  @Schema(description = "The person that describes this agent.")
   private ResourceReference person;
 
   public Agent() {

--- a/gedcomx-model/src/main/java/org/gedcomx/agent/Agent.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/agent/Agent.java
@@ -50,8 +50,7 @@ import java.util.List;
 @XmlType ( name = "Agent" )
 @JsonElementWrapper ( name = "agents" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
-@Schema(description = "An agent, e.g. person, organization, or group. In genealogical research, an agent often takes the role of a contributor." +
-    "\n@see [foaf:Agent](http://xmlns.com/foaf/spec/#term_Agent)")
+@Schema(description = "An agent, e.g. person, organization, or group. In genealogical research, an agent often takes the role of a contributor.")
 public class Agent extends HypermediaEnabledData {
 
   @Schema(description = "The list of names for the agent.")

--- a/gedcomx-model/src/main/java/org/gedcomx/agent/OnlineAccount.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/agent/OnlineAccount.java
@@ -33,7 +33,7 @@ public class OnlineAccount extends ExtensibleData {
   @Schema(description = "The homepage of the service that provides this account.")
   private ResourceReference serviceHomepage;
 
-  @Schema(description = "The name associated with this account.")
+  @Schema(description = "The name associated the holder of this account with the account.")
   private String accountName;
 
   public OnlineAccount() {

--- a/gedcomx-model/src/main/java/org/gedcomx/agent/OnlineAccount.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/agent/OnlineAccount.java
@@ -33,7 +33,7 @@ public class OnlineAccount extends ExtensibleData {
   @Schema(description = "The homepage of the service that provides this account.")
   private ResourceReference serviceHomepage;
 
-  @Schema(description = "The name associated the holder of this account with the account.")
+  @Schema(description = "The name associated with this account.")
   private String accountName;
 
   public OnlineAccount() {

--- a/gedcomx-model/src/main/java/org/gedcomx/agent/OnlineAccount.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/agent/OnlineAccount.java
@@ -15,6 +15,7 @@
  */
 package org.gedcomx.agent;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.gedcomx.common.ExtensibleData;
 import org.gedcomx.common.ResourceReference;
 
@@ -26,9 +27,13 @@ import jakarta.xml.bind.annotation.XmlType;
  * @author Ryan Heaton
  */
 @XmlType( name = "OnlineAccount" )
+@Schema(description = "An online account for a web application.")
 public class OnlineAccount extends ExtensibleData {
 
+  @Schema(description = "The homepage of the service that provides this account.")
   private ResourceReference serviceHomepage;
+
+  @Schema(description = "The name associated the holder of this account with the account.")
   private String accountName;
 
   public OnlineAccount() {

--- a/gedcomx-model/src/main/java/org/gedcomx/common/Attribution.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/Attribution.java
@@ -17,6 +17,8 @@ package org.gedcomx.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.webcohesion.enunciate.metadata.Facet;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import org.gedcomx.agent.Agent;
 import org.gedcomx.rt.GedcomxConstants;
 import org.gedcomx.rt.RDFRange;
@@ -38,13 +40,25 @@ import java.util.Date;
 @XmlType ( name = "Attribution", propOrder = { "contributor", "modified", "changeMessage", "changeMessageResource", "creator", "created" } )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
 @SuppressWarnings("gedcomx:no_id")
+@Schema(description = "Attribution for genealogical information. Attribution is used to model who is contributing/modifying information, when they contributed it, and why they are making the contribution/modification.")
 public class Attribution extends ExtensibleData {
 
+  @Schema(description = "Reference to the contributor of the attributed data.")
   private ResourceReference contributor;
+
+  @Schema(description = "Reference to the creator of the attributed data. The creator might be different from the contributor if the attributed data has been modified since it was created.")
   private ResourceReference creator;
+
+  @Schema(description = "The modified timestamp for the attributed data.")
   private Date modified;
+
+  @Schema(description = "The created timestamp for the attributed data.")
   private Date created;
+
+  @Schema(description = "The \"change message\" for the attributed data provided by the contributor.")
   private String changeMessage;
+
+  @Schema(description = "A reference to the change message for the attributed data provided by the contributor.")
   private URI changeMessageResource;
 
   public Attribution() {

--- a/gedcomx-model/src/main/java/org/gedcomx/common/EvidenceReference.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/EvidenceReference.java
@@ -17,6 +17,7 @@ package org.gedcomx.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.webcohesion.enunciate.metadata.Facet;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.gedcomx.links.HypermediaEnabledData;
 import org.gedcomx.links.Link;
 import org.gedcomx.rt.GedcomxConstants;
@@ -38,10 +39,16 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlType ( name = "EvidenceReference" )
 @JsonElementWrapper ( name = "evidence" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A reference to a resource that is being used as evidence.")
 public final class EvidenceReference extends HypermediaEnabledData implements Attributable {
 
+  @Schema(description = "The URI to the resource being referenced as evidence.")
   private URI resource;
+
+  @Schema(description = "The resource id of the resource being referenced. Used as an extension attribute when resolving the resource is inconvenient.")
   private String resourceId;
+
+  @Schema(description = "Attribution metadata for evidence reference.")
   private Attribution attribution;
 
   public EvidenceReference() {

--- a/gedcomx-model/src/main/java/org/gedcomx/common/ExtensibleData.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/ExtensibleData.java
@@ -16,6 +16,7 @@
 package org.gedcomx.common;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.gedcomx.rt.SupportsExtensionElements;
 
 import jakarta.xml.bind.JAXBElement;
@@ -28,10 +29,16 @@ import java.util.*;
  * @author Ryan Heaton
  */
 @XmlType( name = "ExtensibleData" )
+@Schema(description = "A set of data that supports extension elements.")
 public abstract class ExtensibleData implements SupportsExtensionElements, HasTransientProperties {
 
+  @Schema(description = "A local, context-specific id for the data.")
   private String id;
+
+  @Schema(description = "Custom extension elements for a conclusion.")
   protected List<Object> extensionElements;
+
+  @Schema(description = "Transient properties that are not to be serialized.")
   protected final Map<String, Object> transientProperties = new TreeMap<String, Object>();
 
   protected ExtensibleData() {

--- a/gedcomx-model/src/main/java/org/gedcomx/common/ExtensibleData.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/ExtensibleData.java
@@ -38,7 +38,6 @@ public abstract class ExtensibleData implements SupportsExtensionElements, HasTr
   @Schema(description = "Custom extension elements for a conclusion.")
   protected List<Object> extensionElements;
 
-  @Schema(description = "Transient properties that are not to be serialized.")
   protected final Map<String, Object> transientProperties = new TreeMap<String, Object>();
 
   protected ExtensibleData() {

--- a/gedcomx-model/src/main/java/org/gedcomx/common/Note.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/Note.java
@@ -43,7 +43,7 @@ import java.util.Objects;
 @Schema(description = "A note about a genealogical resource (e.g. conclusion or source).")
 public class Note extends HypermediaEnabledData implements Attributable, HasText {
 
-  @Schema(description = "The language of the note.")
+  @Schema(description = "The language of the note. See http://www.w3.org/International/articles/language-tags/")
   private String lang;
 
   @Schema(description = "The subject of the note. This is a short title describing the contents of the note text.")

--- a/gedcomx-model/src/main/java/org/gedcomx/common/Note.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/Note.java
@@ -17,6 +17,7 @@ package org.gedcomx.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.webcohesion.enunciate.metadata.Facet;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.gedcomx.links.HypermediaEnabledData;
 import org.gedcomx.links.Link;
 import org.gedcomx.rt.GedcomxConstants;
@@ -39,11 +40,19 @@ import java.util.Objects;
 @JsonElementWrapper ( name = "notes" )
 @XmlType ( name = "Note", propOrder = {"subject", "text", "attribution"} )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A note about a genealogical resource (e.g. conclusion or source).")
 public class Note extends HypermediaEnabledData implements Attributable, HasText {
 
+  @Schema(description = "The language of the note.")
   private String lang;
+
+  @Schema(description = "The subject of the note. This is a short title describing the contents of the note text.")
   private String subject;
+
+  @Schema(description = "The text of the note.")
   private String text;
+
+  @Schema(description = "Attribution metadata for a note.")
   private Attribution attribution;
 
   public Note() {

--- a/gedcomx-model/src/main/java/org/gedcomx/common/Qualifier.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/Qualifier.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.gedcomx.rt.ControlledVocabulary;
 import org.gedcomx.rt.json.JsonElementWrapper;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
@@ -38,9 +39,13 @@ import jakarta.xml.bind.annotation.XmlValue;
 @JsonElementWrapper(name = "qualifiers")
 @XmlType( name = "Qualifier" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A data qualifier. Qualifiers are used to \"qualify\" certain data elements to provide additional context, information, or details.")
 public final class Qualifier {
 
+  @Schema(description = "The name of the qualifier. The name should be an element of a constrained vocabulary and is used to determine meaning of the qualifier.")
   private URI name;
+
+  @Schema(description = "The value of the qualifier. Some qualifiers may not have values, indicating that the qualifier is to be treated more like a \"tag\".")
   private String value;
 
   public Qualifier() {

--- a/gedcomx-model/src/main/java/org/gedcomx/common/ResourceReference.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/ResourceReference.java
@@ -18,6 +18,7 @@ package org.gedcomx.common;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.webcohesion.enunciate.metadata.Facet;
 import com.webcohesion.enunciate.metadata.Facets;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.gedcomx.rt.GedcomxConstants;
 import org.gedcomx.rt.json.JsonElementWrapper;
 
@@ -36,9 +37,13 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlType ( name = "ResourceReference" )
 @JsonElementWrapper ( name = "resourceReference" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A generic reference to a resource.")
 public final class ResourceReference {
 
+  @Schema(description = "The URI to the resource being referenced.")
   private URI resource;
+
+  @Schema(description = "The resource id of the resource being referenced. Used as an extension attribute when resolving the resource is inconvenient.")
   private String resourceId;
 
   public ResourceReference() {

--- a/gedcomx-model/src/main/java/org/gedcomx/common/ResourceReference.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/ResourceReference.java
@@ -40,7 +40,7 @@ import jakarta.xml.bind.annotation.XmlType;
 @Schema(description = "A generic reference to a resource.")
 public final class ResourceReference {
 
-  @Schema(description = "The URI to the resource being referenced.")
+  @Schema(description = "The URI to the resource. For more information, see Architecture of the World Wide Web, Volume One, Section 2")
   private URI resource;
 
   @Schema(description = "The resource id of the resource being referenced. Used as an extension attribute when resolving the resource is inconvenient.")

--- a/gedcomx-model/src/main/java/org/gedcomx/common/TextValue.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/TextValue.java
@@ -34,7 +34,7 @@ import jakarta.xml.bind.annotation.XmlValue;
 @Schema(description = "An element representing a text value that may be in a specific language.")
 public class TextValue {
 
-  @Schema(description = "The language of the text value.")
+  @Schema(description = "The language of the text value. See http://www.w3.org/International/articles/language-tags/")
   private String lang;
 
   @Schema(description = "The text value.")

--- a/gedcomx-model/src/main/java/org/gedcomx/common/TextValue.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/TextValue.java
@@ -17,6 +17,7 @@ package org.gedcomx.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.webcohesion.enunciate.metadata.Facet;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.gedcomx.rt.GedcomxConstants;
 
 import javax.xml.XMLConstants;
@@ -30,9 +31,13 @@ import jakarta.xml.bind.annotation.XmlValue;
  */
 @XmlType ( name = "TextValue" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "An element representing a text value that may be in a specific language.")
 public class TextValue {
 
+  @Schema(description = "The language of the text value.")
   private String lang;
+
+  @Schema(description = "The text value.")
   private String value;
 
   public TextValue() {

--- a/gedcomx-model/src/main/java/org/gedcomx/common/URI.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/common/URI.java
@@ -19,6 +19,7 @@ package org.gedcomx.common;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
@@ -28,8 +29,10 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlJavaTypeAdapter(URIAdapter.class)
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A wrapper object for a URI.")
 public final class URI {
 
+  @Schema(description = "The URI value.")
   private final String value;
 
   public URI(java.net.URI value) {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Conclusion.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Conclusion.java
@@ -20,6 +20,7 @@ import com.webcohesion.enunciate.metadata.Facet;
 import com.webcohesion.enunciate.metadata.qname.XmlQNameEnumRef;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.gedcomx.common.*;
 import org.gedcomx.links.HypermediaEnabledData;
 import org.gedcomx.links.Link;
@@ -46,14 +47,28 @@ import java.util.stream.Stream;
  */
 @XmlType ( name = "Conclusion", propOrder = { "attribution", "sources", "analysis", "notes" })
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A genealogical conclusion.")
 public abstract class Conclusion extends HypermediaEnabledData implements Attributable, ReferencesSources, HasNotes {
 
+  @Schema(description = "The language of the conclusion. See [http://www.w3.org/International/articles/language-tags/](http://www.w3.org/International/articles/language-tags/)")
   private String lang;
+
+  @Schema(description = "The level of confidence the contributor has about the data.")
   private URI confidence;
+
+  @Schema(description = "The source references for a conclusion.")
   private List<SourceReference> sources;
+
+  @Schema(description = "Notes about a person.")
   private List<Note> notes;
+
+  @Schema(description = "Attribution metadata for a conclusion.")
   private Attribution attribution;
+
+  @Schema(description = "A reference to the analysis document explaining the analysis that went into this conclusion.")
   private ResourceReference analysis;
+
+  @Schema(description = "A sort key in relation to other facts for display purposes.")
   private String sortKey;
 
   protected Conclusion() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Date.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Date.java
@@ -64,7 +64,6 @@ public class Date extends ExtensibleData implements HasFields {
       "GEDCOM X core, but as extension elements by GEDCOM X RS.")
   private List<TextValue> normalized;
 
-  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   public Date() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Date.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Date.java
@@ -31,6 +31,7 @@ import org.gedcomx.rt.GedcomxConstants;
 import org.gedcomx.rt.GedcomxModelVisitor;
 import org.gedcomx.types.ConfidenceLevel;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
@@ -47,12 +48,23 @@ import java.util.stream.Stream;
 @ClientName ("DateInfo")
 @XmlType ( name = "Date", propOrder = { "original", "formal", "normalizedExtensions", "fields"})
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A concluded genealogical date.")
 public class Date extends ExtensibleData implements HasFields {
 
+  @Schema(description = "The original text as supplied by the user.")
   private String original;
+
+  @Schema(description = "The standardized and/or normalized formal value.")
   private String formal;
+
+  @Schema(description = "The level of confidence the contributor has about the data.")
   private URI confidence;
+
+  @Schema(description = "The list of normalized values for the date, provided for display purposes by the application. Normalized values are not specified by " +
+      "GEDCOM X core, but as extension elements by GEDCOM X RS.")
   private List<TextValue> normalized;
+
+  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   public Date() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/DisplayProperties.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/DisplayProperties.java
@@ -21,6 +21,7 @@ import com.webcohesion.enunciate.metadata.Facet;
 import org.gedcomx.common.ExtensibleData;
 import org.gedcomx.rt.GedcomxConstants;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
@@ -36,22 +37,55 @@ import java.util.List;
 @XmlType (name = "DisplayProperties")
 @Facet (GedcomxConstants.FACET_GEDCOMX_RS)
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(title = "DisplayProperties", description = "A set of display properties for the convenience of quick display, such as for a Web-based application. " +
+    "All display properties are provided in the default locale for the current application context and are NOT considered canonical for the purposes of data exchange.")
 public class DisplayProperties extends ExtensibleData {
 
+  @Schema(description = "The displayable name of the person.")
   private String name;
+
+  @Schema(description = "The displayable label for the gender of the person.")
   private String gender;
+
+  @Schema(description = "The displayable label for the lifespan of the person.")
   private String lifespan;
+
+  @Schema(description = "The displayable label for the birth date of the person.")
   private String birthDate;
+
+  @Schema(description = "The displayable label for the birth place of the person.")
   private String birthPlace;
+
+  @Schema(description = "The displayable label for the death date of the person.")
   private String deathDate;
+
+  @Schema(description = "The displayable label for the death place of the person.")
   private String deathPlace;
+
+  @Schema(description = "The displayable label for the marriage date of the person.")
   private String marriageDate;
+
+  @Schema(description = "The displayable label for the marriage place of the person.")
   private String marriagePlace;
+
+  @Schema(description = "The context-specific ascendancy number for the person in relation to the other persons in the request. " +
+      "The ancestry number is defined using the Ahnentafel numbering system.")
   private String ascendancyNumber;
+
+  @Schema(description = "The context-specific descendancy number for the person in relation to the other persons in the request. " +
+      "The descendancy number is defined using the d'Aboville numbering system.")
   private String descendancyNumber;
+
+  @Schema(description = "The context-specific relationship description for the person in relation to the root person in the request.")
   private String relationshipDescription;
+
+  @Schema(description = "The family views where this person is a parent.")
   private List<FamilyView> familiesAsParent;
+
+  @Schema(description = "The family views where this person is a child.")
   private List<FamilyView> familiesAsChild;
+
+  @Schema(description = "The role of this person in the current display context.")
   private String role;
 
   public DisplayProperties() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Document.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Document.java
@@ -29,6 +29,7 @@ import org.gedcomx.source.SourceReference;
 import org.gedcomx.types.ConfidenceLevel;
 import org.gedcomx.types.DocumentType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
@@ -43,14 +44,22 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlType(name = "Document", propOrder = { "text" })
 @Facet ( GedcomxConstants.FACET_FS_FT_UNSUPPORTED )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "An abstract document that contains derived (conclusionary) text -- for example, a transcription or researcher analysis.")
 public class Document extends Conclusion implements HasText, Attributable {
   
   public static final String TEXT_TYPE_PLAIN = "plain";
   public static final String TEXT_TYPE_XHTML = "xhtml";
 
+  @Schema(description = "Whether this document has been identified as \"extracted\", meaning it captures information extracted from a single source.")
   private Boolean extracted;
+
+  @Schema(description = "The type of the document.")
   private URI type;
+
+  @Schema(description = "The text type of the document.")
   private String textType;
+
+  @Schema(description = "The document text.")
   private String text;
 
   public Document() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Event.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Event.java
@@ -30,6 +30,7 @@ import org.gedcomx.source.SourceReference;
 import org.gedcomx.types.ConfidenceLevel;
 import org.gedcomx.types.EventType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -47,11 +48,19 @@ import java.util.stream.Stream;
 @XmlType ( name = "Event", propOrder = { "date", "place", "roles" } )
 @Facet ( GedcomxConstants.FACET_FS_FT_UNSUPPORTED )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A historical event.")
 public class Event extends Subject implements HasDateAndPlace {
 
+  @Schema(description = "The type of the event.")
   private URI type;
+
+  @Schema(description = "The date of this event.")
   private Date date;
+
+  @Schema(description = "The place of this event.")
   private PlaceReference place;
+
+  @Schema(description = "The roles played in this event.")
   private List<EventRole> roles;
 
   /**

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/EventRole.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/EventRole.java
@@ -32,6 +32,7 @@ import org.gedcomx.source.SourceReference;
 import org.gedcomx.types.ConfidenceLevel;
 import org.gedcomx.types.EventRoleType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
@@ -44,10 +45,16 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlType ( name = "EventRole", propOrder = { "person", "details" } )
 @Facet ( GedcomxConstants.FACET_FS_FT_UNSUPPORTED )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A role that a specific person plays in an event.")
 public class EventRole extends Conclusion {
 
+  @Schema(description = "Reference to the person playing the role in the event.")
   private ResourceReference person;
+
+  @Schema(description = "The role type.")
   private URI type;
+
+  @Schema(description = "Details about the role of the person in the event.")
   private String details;
 
   public EventRole() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Fact.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Fact.java
@@ -32,6 +32,7 @@ import org.gedcomx.source.SourceReference;
 import org.gedcomx.types.ConfidenceLevel;
 import org.gedcomx.types.FactType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -45,17 +46,32 @@ import java.util.stream.Stream;
 @XmlRootElement
 @JsonElementWrapper ( name = "facts" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A conclusion about a fact applicable to a person or relationship.")
 public class Fact extends Conclusion implements HasDateAndPlace, HasFields {
 
   /**
    * @see org.gedcomx.types.FactType
    */
+  @Schema(description = "The type of the fact.")
   private URI type;
+
+  @Schema(description = "The date of applicability of this fact.")
   private Date date;
+
+  @Schema(description = "The place of applicability of this fact.")
   private PlaceReference place;
+
+  @Schema(description = "The value as supplied by the user.")
   private String value;
+
+  @Schema(description = "The qualifiers associated with this fact.")
   private List<Qualifier> qualifiers;
+
+  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
+
+  @Schema(description = "Indicator of whether this fact is the \"primary\" fact of the record from which the subject was extracted. " +
+      "Applicable only to extracted persons/relationships. The meaning of this flag outside the scope of an extracted subject is undefined.")
   private Boolean primary;
 
   /**

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Fact.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Fact.java
@@ -67,7 +67,6 @@ public class Fact extends Conclusion implements HasDateAndPlace, HasFields {
   @Schema(description = "The qualifiers associated with this fact.")
   private List<Qualifier> qualifiers;
 
-  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   @Schema(description = "Indicator of whether this fact is the \"primary\" fact of the record from which the subject was extracted. " +

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/FamilyView.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/FamilyView.java
@@ -23,6 +23,7 @@ import org.gedcomx.links.HypermediaEnabledData;
 import org.gedcomx.rt.GedcomxConstants;
 import org.gedcomx.rt.json.JsonElementWrapper;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
@@ -42,10 +43,23 @@ import java.util.List;
 @JsonElementWrapper( name = "families" )
 @XmlType( name = "FamilyView", propOrder = { "parent1", "parent2", "children"} )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A family view, meaning up to two parents and a list of children who have those parents in common.\n" +
+    " Relationships carry the canonical information for this view, and the relationships must be used\n" +
+    " to get Facts (lineage types, marriages, etc.) about the relationships covered by a Family.\n" +
+    " The Family data type provides a convenient way to see the typical family views without having to do\n" +
+    " the calculations to derive them. There should only be one family for each unique set of parents,\n" +
+    " and only one for each single-parent family with a particular parent.")
 public class FamilyView extends HypermediaEnabledData {
 
+  @Schema(description = "A reference to a parent in the family. The name \"parent1\" is used only to distinguish it from\n" +
+      " the other parent in this family and implies neither order nor role.")
   private ResourceReference parent1; // First parent
+
+  @Schema(description = "A reference to a parent in the family. The name \"parent2\" is used only to distinguish it from\n" +
+      " the other parent in this family and implies neither order nor role.")
   private ResourceReference parent2; // Second parent
+
+  @Schema(description = "A list of references to the children of this family.")
   private List<ResourceReference> children; // List of children
 
   public FamilyView() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/FamilyView.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/FamilyView.java
@@ -43,19 +43,19 @@ import java.util.List;
 @JsonElementWrapper( name = "families" )
 @XmlType( name = "FamilyView", propOrder = { "parent1", "parent2", "children"} )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
-@Schema(description = "A family view, meaning up to two parents and a list of children who have those parents in common.\n" +
-    " Relationships carry the canonical information for this view, and the relationships must be used\n" +
-    " to get Facts (lineage types, marriages, etc.) about the relationships covered by a Family.\n" +
-    " The Family data type provides a convenient way to see the typical family views without having to do\n" +
-    " the calculations to derive them. There should only be one family for each unique set of parents,\n" +
+@Schema(description = "A family view, meaning up to two parents and a list of children who have those parents in common." +
+    " Relationships carry the canonical information for this view, and the relationships must be used" +
+    " to get Facts (lineage types, marriages, etc.) about the relationships covered by a Family." +
+    " The Family data type provides a convenient way to see the typical family views without having to do" +
+    " the calculations to derive them. There should only be one family for each unique set of parents," +
     " and only one for each single-parent family with a particular parent.")
 public class FamilyView extends HypermediaEnabledData {
 
-  @Schema(description = "A reference to a parent in the family. The name \"parent1\" is used only to distinguish it from\n" +
+  @Schema(description = "A reference to a parent in the family. The name \"parent1\" is used only to distinguish it from" +
       " the other parent in this family and implies neither order nor role.")
   private ResourceReference parent1; // First parent
 
-  @Schema(description = "A reference to a parent in the family. The name \"parent2\" is used only to distinguish it from\n" +
+  @Schema(description = "A reference to a parent in the family. The name \"parent2\" is used only to distinguish it from" +
       " the other parent in this family and implies neither order nor role.")
   private ResourceReference parent2; // Second parent
 

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Gender.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Gender.java
@@ -54,10 +54,9 @@ import java.util.List;
 @Schema(description = "A gender conclusion.")
 public class Gender extends Conclusion implements HasFields {
 
-  @Schema(description = "The type")
+  @Schema(description = "The URI that identifies the type of Gender.")
   private URI type;
 
-  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   /**

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Gender.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Gender.java
@@ -35,6 +35,7 @@ import org.gedcomx.source.SourceReference;
 import org.gedcomx.types.ConfidenceLevel;
 import org.gedcomx.types.GenderType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.*;
 
 import java.util.ArrayList;
@@ -50,9 +51,13 @@ import java.util.List;
 @XmlRootElement
 @JsonElementWrapper ( name = "genders" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A gender conclusion.")
 public class Gender extends Conclusion implements HasFields {
 
+  @Schema(description = "The type")
   private URI type;
+
+  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   /**

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Identifier.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Identifier.java
@@ -24,6 +24,7 @@ import org.gedcomx.common.URI;
 import org.gedcomx.rt.json.HasJsonKey;
 import org.gedcomx.types.IdentifierType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
@@ -36,9 +37,13 @@ import jakarta.xml.bind.annotation.XmlValue;
  */
 @XmlType ( name = "Identifier" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "An identifier for a resource.")
 public final class Identifier implements HasJsonKey {
 
+  @Schema(description = "Whether the type of this identifier implies that the value is unique among all other identifiers of the same type.")
   private boolean hasUniqueKey = false;
+
+  @Schema(description = "The id value.")
   private URI value;
   
   /**

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Name.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Name.java
@@ -34,6 +34,7 @@ import org.gedcomx.types.ConfidenceLevel;
 import org.gedcomx.types.NamePartType;
 import org.gedcomx.types.NameType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.*;
 
 import java.util.ArrayList;
@@ -51,14 +52,22 @@ import java.util.stream.Stream;
 @XmlRootElement
 @JsonElementWrapper ( name = "names" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A name conclusion.")
 public class Name extends Conclusion {
 
   /**
    * @see org.gedcomx.types.NameType
    */
+  @Schema(description = "The type of the name.")
   private URI type;
+
+  @Schema(description = "The date the name was first applied or adopted.")
   private Date date;
+
+  @Schema(description = "Alternate forms of the name, such as the romanized form of a non-latin name.")
   private List<NameForm> nameForms;
+
+  @Schema(description = "Whether the conclusion is preferred above other conclusions of the same type. Useful, for example, for display purposes.")
   private Boolean preferred;
 
   public Name() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/NameForm.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/NameForm.java
@@ -56,7 +56,6 @@ public class NameForm extends ExtensibleData implements HasFields {
   @Schema(description = "The different parts of the name form.")
   private List<NamePart> parts;
 
-  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   public NameForm() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/NameForm.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/NameForm.java
@@ -26,6 +26,8 @@ import org.gedcomx.rt.GedcomxModelVisitor;
 import org.gedcomx.types.NamePartType;
 
 import javax.xml.XMLConstants;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
@@ -42,11 +44,19 @@ import java.util.stream.Stream;
  */
 @XmlType ( name = "NameForm", propOrder = { "fullText", "parts", "fields"})
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A form of a name.")
 public class NameForm extends ExtensibleData implements HasFields {
 
+  @Schema(description = "The language of the conclusion. See http://www.w3.org/International/articles/language-tags/")
   private String lang;
+
+  @Schema(description = "The full text of the name form.")
   private String fullText;
+
+  @Schema(description = "The different parts of the name form.")
   private List<NamePart> parts;
+
+  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   public NameForm() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/NamePart.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/NamePart.java
@@ -63,7 +63,6 @@ public final class NamePart extends ExtensibleData implements HasFields {
   @Schema(description = "The qualifiers associated with this name part.")
   private List<Qualifier> qualifiers;
 
-  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   public NamePart() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/NamePart.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/NamePart.java
@@ -29,6 +29,7 @@ import org.gedcomx.rt.GedcomxConstants;
 import org.gedcomx.rt.GedcomxModelVisitor;
 import org.gedcomx.types.NamePartType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
@@ -47,14 +48,22 @@ import java.util.stream.Stream;
  */
 @XmlType ( name = "NamePart" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A part of a name.")
 public final class NamePart extends ExtensibleData implements HasFields {
 
   /**
    * @see org.gedcomx.types.NamePartType
    */
+  @Schema(description = "The type of the name part.")
   private URI type;
+
+  @Schema(description = "The value of the name part.")
   private String value;
+
+  @Schema(description = "The qualifiers associated with this name part.")
   private List<Qualifier> qualifiers;
+
+  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   public NamePart() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Person.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Person.java
@@ -65,22 +65,23 @@ public class Person extends Subject implements HasFacts, HasFields {
   @Schema(description = "Whether this person has been designated for limited distribution or display.")
   private Boolean isPrivate;
 
-  @Schema(description = "Living status of the person as treated by the system. The value of this property is intended to be based on a system-specific calculation and therefore has limited portability. Conclusions about the living status of a person can be modeled with a fact.")
+  @Schema(description = "Living status of the person as treated by the system. The value of this property is intended to be based on a system-specific " +
+      "calculation and therefore has limited portability. Conclusions about the living status of a person can be modeled with a fact.")
   private Boolean living;
 
-  @Schema(description = "Indicator of whether this person is the 'principal' person extracted from the record. Applicable only to extracted persons. The meaning of this flag outside the scope of an extracted person is undefined.")
+  @Schema(description = "Indicator of whether this person is the 'principal' person extracted from the record. Applicable only to extracted persons. " +
+      "The meaning of this flag outside the scope of an extracted person is undefined.")
   private Boolean principal;
 
-  @Schema(description = "The gender of the person")
+  @Schema(description = "The gender conclusion for the person.")
   private Gender gender;
 
-  @Schema(description = "The names of the person.")
+  @Schema(description = "The name conclusions for the person.")
   private List<Name> names;
 
-  @Schema(description = "The facts of the person.")
+  @Schema(description = "The fact conclusions for the person.")
   private List<Fact> facts;
 
-  @Schema(description = "The fields being used as evidence.")
   private List<Field> fields; // person-specific fields, such as used in an extracted historical record.
 
   @Schema(description = "Display properties for the person. Display properties are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.")

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Person.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Person.java
@@ -20,6 +20,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -58,15 +59,31 @@ import org.gedcomx.types.NameType;
 @JsonElementWrapper (name = "persons")
 @XmlType ( name = "Person", propOrder = { "private", "living", "principal", "gender", "names", "facts", "fields", "displayExtension" } )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A person.")
 public class Person extends Subject implements HasFacts, HasFields {
 
+  @Schema(description = "Whether this person has been designated for limited distribution or display.")
   private Boolean isPrivate;
+
+  @Schema(description = "Living status of the person as treated by the system. The value of this property is intended to be based on a system-specific calculation and therefore has limited portability. Conclusions about the living status of a person can be modeled with a fact.")
   private Boolean living;
+
+  @Schema(description = "Indicator of whether this person is the 'principal' person extracted from the record. Applicable only to extracted persons. The meaning of this flag outside the scope of an extracted person is undefined.")
   private Boolean principal;
+
+  @Schema(description = "The gender of the person")
   private Gender gender;
+
+  @Schema(description = "The names of the person.")
   private List<Name> names;
+
+  @Schema(description = "The facts of the person.")
   private List<Fact> facts;
+
+  @Schema(description = "The fields being used as evidence.")
   private List<Field> fields; // person-specific fields, such as used in an extracted historical record.
+
+  @Schema(description = "Display properties for the person. Display properties are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.")
   private DisplayProperties display;
 
   public Person() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDescription.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDescription.java
@@ -26,6 +26,7 @@ import org.gedcomx.source.SourceDescription;
 import org.gedcomx.source.SourceReference;
 import org.gedcomx.types.ConfidenceLevel;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
@@ -42,16 +43,36 @@ import java.util.stream.Stream;
  */
 @XmlType ( name = "PlaceDescription", propOrder = { "names", "temporalDescription", "latitude", "longitude", "spatialDescription", "place", "jurisdiction", "displayExtension" } )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A PlaceDescription is used to describe the details of a place in terms of its name and possibly its type, time period, and/or a " +
+    "geospatial description -- a description of a place as a snapshot in time.")
 public class PlaceDescription extends Subject {
 
+  @Schema(description = "An ordered list of standardized (or normalized), fully-qualified (in terms of what is known of the applicable jurisdictional hierarchy) " +
+      "names for this place that are applicable to this description of this place.")
   private List<TextValue> names;
+
+  @Schema(description = "An implementation-specific uniform resource identifier (URI) used to identify the type of a place (e.g., address, city, county, province, state, country, etc.).")
   private URI type;
+
+  @Schema(description = "A description of the time period to which this place description is relevant.")
   private Date temporalDescription;
+
+  @Schema(description = "Degrees north or south of the Equator (0.0 degrees).   Values range from −90.0 degrees (south) to 90.0 degrees (north).")
   private Double latitude;
+
+  @Schema(description = "Angular distance in degrees, relative to the Prime Meridian.   Values range from −180.0 degrees (west of the Meridian) to 180.0 degrees (east of the Meridian).")
   private Double longitude;
+
+  @Schema(description = "A reference to a geospatial description of this place.")
   private ResourceReference place;
+
+  @Schema(description = "A reference to a geospatial description of this place.")
   private ResourceReference spatialDescription;
+
+  @Schema(description = "A reference to a description of the jurisdiction this place.")
   private ResourceReference jurisdiction;
+
+  @Schema(description = "Display properties for the place. Display properties are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.")
   private PlaceDisplayProperties display;
 
   public PlaceDescription() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDescription.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDescription.java
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
 public class PlaceDescription extends Subject {
 
   @Schema(description = "An ordered list of standardized (or normalized), fully-qualified (in terms of what is known of the applicable jurisdictional hierarchy) " +
-      "names for this place that are applicable to this description of this place.")
+      "names for this place that are applicable to this description of this place. The list MUST include at least one value. It is RECOMMENDED that instances include a single name and any equivalents from other cultural contexts; name variants should more typically be described in separate PlaceDescription instances. The list is assumed to be given in order of preference, with the most preferred value in the first position in the list.")
   private List<TextValue> names;
 
   @Schema(description = "An implementation-specific uniform resource identifier (URI) used to identify the type of a place (e.g., address, city, county, province, state, country, etc.).")
@@ -57,16 +57,16 @@ public class PlaceDescription extends Subject {
   @Schema(description = "A description of the time period to which this place description is relevant.")
   private Date temporalDescription;
 
-  @Schema(description = "Degrees north or south of the Equator (0.0 degrees).   Values range from −90.0 degrees (south) to 90.0 degrees (north).")
+  @Schema(description = "Degrees north or south of the Equator (0.0 degrees). Values range from −90.0 degrees (south) to 90.0 degrees (north).")
   private Double latitude;
 
-  @Schema(description = "Angular distance in degrees, relative to the Prime Meridian.   Values range from −180.0 degrees (west of the Meridian) to 180.0 degrees (east of the Meridian).")
+  @Schema(description = "Angular distance in degrees, relative to the Prime Meridian. Values range from −180.0 degrees (west of the Meridian) to 180.0 degrees (east of the Meridian).")
   private Double longitude;
 
-  @Schema(description = "A reference to a geospatial description of this place.")
+  @Schema(description = "A reference to the place being described.")
   private ResourceReference place;
 
-  @Schema(description = "A reference to a geospatial description of this place.")
+  @Schema(description = "A reference to a geospatial description of this place. It is RECOMMENDED that this description resolve to a KML document.")
   private ResourceReference spatialDescription;
 
   @Schema(description = "A reference to a description of the jurisdiction this place.")

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDisplayProperties.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceDisplayProperties.java
@@ -20,6 +20,7 @@ import com.webcohesion.enunciate.metadata.Facet;
 import org.gedcomx.common.ExtensibleData;
 import org.gedcomx.rt.GedcomxConstants;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlType;
 
 
@@ -31,10 +32,17 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlType ( name = "PlaceDisplayProperties" )
 @Facet ( GedcomxConstants.FACET_GEDCOMX_RS )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A set of display properties for places for the convenience of quick display, such as for a Web-based application. " +
+    "All display properties are provided in the default locale for the current application context and are NOT considered canonical for the purposes of data exchange.")
 public class PlaceDisplayProperties extends ExtensibleData {
 
+  @Schema(description = "The displayable name of the place.")
   private String name;
+
+  @Schema(description = "The displayable full name of the place.")
   private String fullName;
+
+  @Schema(description = "The displayable type of the place.")
   private String type;
 
   public PlaceDisplayProperties() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceReference.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceReference.java
@@ -59,7 +59,6 @@ public class PlaceReference extends ExtensibleData implements HasFields {
   @Schema(description = "The level of confidence the contributor has about the data.")
   private URI confidence;
 
-  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   @Schema(description = "The list of normalized values for the place, provided for display purposes by the application. " +

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceReference.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/PlaceReference.java
@@ -30,6 +30,7 @@ import org.gedcomx.rt.GedcomxModelVisitor;
 import org.gedcomx.rt.RDFRange;
 import org.gedcomx.types.ConfidenceLevel;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
@@ -46,12 +47,23 @@ import java.util.stream.Stream;
  */
 @XmlType ( name = "PlaceReference", propOrder = { "original", "normalizedExtensions", "fields" })
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A reference to genealogical place.")
 public class PlaceReference extends ExtensibleData implements HasFields {
 
+  @Schema(description = "The original value as supplied by the user.")
   private String original;
+
+  @Schema(description = "A reference to a description of the place being referenced.")
   private URI descriptionRef;
+
+  @Schema(description = "The level of confidence the contributor has about the data.")
   private URI confidence;
+
+  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
+
+  @Schema(description = "The list of normalized values for the place, provided for display purposes by the application. " +
+      "Normalized values are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.")
   private List<TextValue> normalized;
 
   public PlaceReference() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Relationship.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Relationship.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -58,15 +59,27 @@ import org.gedcomx.types.RelationshipType;
 @JsonElementWrapper ( name = "relationships" )
 @XmlType ( name = "Relationship", propOrder = { "person1", "person2", "facts", "fields" } )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = " A relationship between two or more persons.")
 public class Relationship extends Subject implements HasFacts, HasFields {
 
   /**
    * @see org.gedcomx.types.RelationshipType
    */
+  @Schema(description = "The type of this relationship.")
   private URI type;
+
+  @Schema(description = "A reference to a person in the relationship. The name \"person1\" is used only to distinguish it from the other person in this " +
+      "relationship and implies neither order nor role. When the relationship type implies direction, it goes from \"person1\" to \"person2\".")
   private ResourceReference person1;
+
+  @Schema(description = "A reference to a person in the relationship. The name \"person2\" is used only to distinguish it from the other person in this " +
+      "relationship and implies neither order nor role. When the relationship type implies direction, it goes from \"person1\" to \"person2\".")
   private ResourceReference person2;
+
+  @Schema(description = "The fact conclusions for the relationship.")
   private List<Fact> facts;
+
+  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   public Relationship() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Relationship.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Relationship.java
@@ -79,7 +79,6 @@ public class Relationship extends Subject implements HasFacts, HasFields {
   @Schema(description = "The fact conclusions for the relationship.")
   private List<Fact> facts;
 
-  @Schema(description = "The references to the record fields being used as evidence.")
   private List<Field> fields;
 
   public Relationship() {

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Subject.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Subject.java
@@ -50,7 +50,7 @@ import java.util.stream.Stream;
  */
 @XmlType ( name = "Subject", propOrder = { "evidence", "media", "identifiers" })
 @JsonInclude ( JsonInclude.Include.NON_NULL )
-@Schema(description = "The `Subject` data type defines the abstract concept of a genealogical _subject_. A _subject_ is something with a unique and intrinsic identity, e.g., a person, a location on the surface of the earth. We identify that _subject_ in time and space using various supporting _conclusions_, e.g. for a person: things like name, birth date, age, address, etc. We aggregate these supporting _conclusions_ to form an apparently-unique identity by which we can distinguish our _subject_ from all other possible _subjects_")
+@Schema(description = "The `Subject` data type defines the abstract concept of a genealogical _subject_. A _subject_ is something with a unique and intrinsic identity, e.g., a person, a location on the surface of the earth. We identify that _subject_ in time and space using various supporting _conclusions_, e.g. for a person: things like name, birth date, age, address, etc. We aggregate these supporting _conclusions_ to form an apparently-unique identity by which we can distinguish our _subject_ from all other possible _subjects_.")
 public abstract class Subject extends Conclusion implements Attributable {
 
   @Schema(description = "Whether this subject has been identified as 'extracted', meaning it captures information extracted from a single source.")

--- a/gedcomx-model/src/main/java/org/gedcomx/conclusion/Subject.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/conclusion/Subject.java
@@ -29,6 +29,7 @@ import org.gedcomx.types.ConfidenceLevel;
 import org.gedcomx.types.IdentifierType;
 import org.gedcomx.util.JsonIdentifiers;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
@@ -49,11 +50,19 @@ import java.util.stream.Stream;
  */
 @XmlType ( name = "Subject", propOrder = { "evidence", "media", "identifiers" })
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "The `Subject` data type defines the abstract concept of a genealogical _subject_. A _subject_ is something with a unique and intrinsic identity, e.g., a person, a location on the surface of the earth. We identify that _subject_ in time and space using various supporting _conclusions_, e.g. for a person: things like name, birth date, age, address, etc. We aggregate these supporting _conclusions_ to form an apparently-unique identity by which we can distinguish our _subject_ from all other possible _subjects_")
 public abstract class Subject extends Conclusion implements Attributable {
 
+  @Schema(description = "Whether this subject has been identified as 'extracted', meaning it captures information extracted from a single source.")
   private Boolean extracted;
+
+  @Schema(description = "The list of identifiers for the subject.")
   private List<Identifier> identifiers;
+
+  @Schema(description = "References to multimedia resources associated with this subject.")
   private List<SourceReference> media;
+
+  @Schema(description = "References to the evidence being referenced for this subject.")
   private List<EvidenceReference> evidence;
 
   public Subject() {

--- a/gedcomx-model/src/main/java/org/gedcomx/links/HypermediaEnabledData.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/links/HypermediaEnabledData.java
@@ -18,6 +18,7 @@ package org.gedcomx.links;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.webcohesion.enunciate.metadata.Facet;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.gedcomx.common.ExtensibleData;
 import org.gedcomx.common.URI;
 import org.gedcomx.rt.GedcomxConstants;
@@ -28,14 +29,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * An data type that supports hypermedia controls (i.e. links).
+ * A data type that supports hypermedia controls (i.e. links).
  *
  * @author Ryan Heaton
  */
 @XmlType ( name = "HypermediaEnabledData" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A data type that supports hypermedia controls (i.e. links).")
 public abstract class HypermediaEnabledData extends ExtensibleData implements SupportsLinks {
 
+  @Schema(description = "The list of hypermedia links. Links are not specified by GEDCOM X core, but as extension elements by GEDCOM X RS.")
   private List<Link> links;
 
   protected HypermediaEnabledData() {

--- a/gedcomx-model/src/main/java/org/gedcomx/links/Link.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/links/Link.java
@@ -53,7 +53,7 @@ public class Link implements HasJsonKey {
    */
   public static final Set<String> NON_UNIQUE_RELS = new TreeSet<String>(Arrays.asList("alternate", "bookmark", "related", "item"));
 
-  @Schema(description = "The Relationship.")
+  @Schema(description = "The link relationship.")
   private String rel;
 
   @Schema(description = "The target URI of the link.")
@@ -62,19 +62,23 @@ public class Link implements HasJsonKey {
   @Schema(description = "A URI template per RFC 6570, used to link to a range of URIs, such as for the purpose of linking to a query.")
   private String template;
 
-  @Schema(description = "Metadata about the available media type(s) of the resource being linked to.")
+  @Schema(description = "Metadata about the available media type(s) of the resource being linked to. The value of the \"type\" attribute is as " +
+      "defined by the HTTP specification, RFC 2616, Section 3.7. Note that this attribute can be considered an \"Update Control (CU)\" per Amundsen, M. (2011). Hypermedia APIs with HTML5 and Node. O'Reilly.")
   private String type;
 
-  @Schema(description = "Metadata about the available media type(s) of the resource being linked to.")
+  @Schema(description = "Metadata about the available media type(s) of the resource being linked to update (i.e. change the state of) the resource being " +
+      "linked to. The value of the \"accept\" attribute is as defined by the HTTP specification, RFC 2616, Section 3.7. Note that this attribute can be considered an \"Read Control (CR)\" per Amundsen, M. (2011). Hypermedia APIs with HTML5 and Node. O'Reilly.")
   private String accept;
 
-  @Schema(description = "Metadata about the allowable methods that can be used to transition to the resource being linked.")
+  @Schema(description = "Metadata about the allowable methods that can be used to transition to the resource being linked. The value of the \"allow\" " +
+      "attribute is as defined by the HTTP specification, RFC 2616, Section 14.7. Note that this attribute can be considered an \"Method Control (CM)\" per Amundsen, M. (2011). Hypermedia APIs with HTML5 and Node. O'Reilly.")
   private String allow;
 
-  @Schema(description = "The language of the resource being linked to.")
+  @Schema(description = "The language of the resource being linked to. Note that this attribute can be considered an \"Update Control (CU)\" per Amundsen, " +
+      "M. (2011). Hypermedia APIs with HTML5 and Node. O'Reilly.")
   private String hreflang;
 
-  @Schema(description = "The title for the link.")
+  @Schema(description = "Human-readable information about the link.")
   private String title;
 
   @Schema(description = "The number of elements in the page, if this link refers to a page of resources.")

--- a/gedcomx-model/src/main/java/org/gedcomx/links/Link.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/links/Link.java
@@ -56,7 +56,7 @@ public class Link implements HasJsonKey {
   @Schema(description = "The Relationship.")
   private String rel;
 
-  @Schema(description = "The target IRI of the link.")
+  @Schema(description = "The target URI of the link.")
   private URI href;
 
   @Schema(description = "A URI template per RFC 6570, used to link to a range of URIs, such as for the purpose of linking to a query.")
@@ -74,7 +74,7 @@ public class Link implements HasJsonKey {
   @Schema(description = "The language of the resource being linked to.")
   private String hreflang;
 
-  @Schema(description = "Human-readable information about the link.")
+  @Schema(description = "The title for the link.")
   private String title;
 
   @Schema(description = "The number of elements in the page, if this link refers to a page of resources.")

--- a/gedcomx-model/src/main/java/org/gedcomx/links/Link.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/links/Link.java
@@ -24,6 +24,8 @@ import org.gedcomx.rt.json.HasJsonKey;
 import org.gedcomx.rt.json.JsonElementWrapper;
 
 import javax.xml.XMLConstants;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.*;
 import java.util.Arrays;
 import java.util.Set;
@@ -42,6 +44,7 @@ import java.util.TreeSet;
 @SuppressWarnings("gedcomx:no_id")
 @Facet ( GedcomxConstants.FACET_GEDCOMX_RS )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A hypermedia link, used to drive the state of a hypermedia-enabled genealogical data application.")
 public class Link implements HasJsonKey {
 
   /**
@@ -50,16 +53,37 @@ public class Link implements HasJsonKey {
    */
   public static final Set<String> NON_UNIQUE_RELS = new TreeSet<String>(Arrays.asList("alternate", "bookmark", "related", "item"));
 
+  @Schema(description = "The Relationship.")
   private String rel;
+
+  @Schema(description = "The target IRI of the link.")
   private URI href;
+
+  @Schema(description = "A URI template per RFC 6570, used to link to a range of URIs, such as for the purpose of linking to a query.")
   private String template;
+
+  @Schema(description = "Metadata about the available media type(s) of the resource being linked to.")
   private String type;
+
+  @Schema(description = "Metadata about the available media type(s) of the resource being linked to.")
   private String accept;
+
+  @Schema(description = "Metadata about the allowable methods that can be used to transition to the resource being linked.")
   private String allow;
+
+  @Schema(description = "The language of the resource being linked to.")
   private String hreflang;
+
+  @Schema(description = "Human-readable information about the link.")
   private String title;
+
+  @Schema(description = "The number of elements in the page, if this link refers to a page of resources.")
   private Integer count;
+
+  @Schema(description = "The index of the offset of the page, if this link refers to a page of resources.")
   private Integer offset;
+
+  @Schema(description = "The total number of results in the page to which this links, if this link refers to a page of resources.")
   private Integer results;
 
   public Link() {

--- a/gedcomx-model/src/main/java/org/gedcomx/records/Collection.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/Collection.java
@@ -30,6 +30,8 @@ import org.gedcomx.rt.json.JsonElementWrapper;
 import org.gedcomx.util.JsonIdentifiers;
 
 import javax.xml.XMLConstants;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -49,13 +51,25 @@ import java.util.stream.Stream;
 @XmlType ( name = "Collection", propOrder = { "identifiers", "title", "size", "content", "attribution" })
 @com.webcohesion.enunciate.metadata.Facet( GedcomxConstants.FACET_GEDCOMX_RECORD )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A collection of genealogical resources.")
 public class Collection extends HypermediaEnabledData implements Attributable {
 
+  @Schema(description = "The language of this description of the collection.")
   private String lang;
+
+  @Schema(description = "The list of identifiers for the source.")
   private List<Identifier> identifiers;
+
+  @Schema(description = "Descriptions of the content of this collection.")
   private List<CollectionContent> content;
+
+  @Schema(description = "A title for the collection.")
   private String title;
+
+  @Schema(description = "The size of the collection, in terms of the number of items in this collection.")
   private Integer size;
+
+  @Schema(description = "Attribution metadata for this collection.")
   private Attribution attribution;
 
   public Collection() {

--- a/gedcomx-model/src/main/java/org/gedcomx/records/CollectionContent.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/CollectionContent.java
@@ -24,6 +24,7 @@ import org.gedcomx.rt.GedcomxConstants;
 import org.gedcomx.rt.json.JsonElementWrapper;
 import org.gedcomx.types.ResourceType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
@@ -38,10 +39,17 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlType ( name = "CollectionContent" )
 @com.webcohesion.enunciate.metadata.Facet( GedcomxConstants.FACET_GEDCOMX_RECORD )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A description of the content of a collection by resource type.")
 public class CollectionContent extends HypermediaEnabledData {
 
+  @Schema(description = "The type of resource being covered in this collection.")
   private URI resourceType;
+
+  @Schema(description = "The count of the items applicable to this content aspect.")
   private Integer count;
+
+  @Schema(description = "A completeness factor for this content; i.e. what percentage of the total number of items in the collection is included in " +
+      "this content aspect. The completeness factor is a value between 0 and 1.")
   private Float completeness;
 
   public CollectionContent() {

--- a/gedcomx-model/src/main/java/org/gedcomx/records/Field.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/Field.java
@@ -28,6 +28,7 @@ import org.gedcomx.rt.GedcomxModelVisitor;
 import org.gedcomx.rt.json.JsonElementWrapper;
 import org.gedcomx.types.FieldType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
@@ -45,12 +46,16 @@ import java.util.stream.Stream;
 @JsonElementWrapper ( name = "fields" )
 @com.webcohesion.enunciate.metadata.Facet( GedcomxConstants.FACET_GEDCOMX_RECORD )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A field of a record.")
 public class Field extends Conclusion {
 
   /**
    * @see org.gedcomx.types.FieldType
    */
+  @Schema(description = "The type of the field.")
   private URI type;
+
+  @Schema(description = "The set of values for the field.")
   private List<FieldValue> values;
 
   public Field() {

--- a/gedcomx-model/src/main/java/org/gedcomx/records/FieldDescriptor.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/FieldDescriptor.java
@@ -24,6 +24,7 @@ import org.gedcomx.links.HypermediaEnabledData;
 import org.gedcomx.links.Link;
 import org.gedcomx.rt.GedcomxConstants;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
 
@@ -40,10 +41,16 @@ import java.util.stream.Stream;
 @XmlType ( name = "FieldDescriptor", propOrder = { "originalLabel", "descriptions", "values"})
 @com.webcohesion.enunciate.metadata.Facet( GedcomxConstants.FACET_GEDCOMX_RECORD )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A description of a field in a record.")
 public class FieldDescriptor extends HypermediaEnabledData {
 
+  @Schema(description = "The original label for the field, as stated on the original record.")
   private String originalLabel; // what the original form said, e.g,. "Nombre:"
+
+  @Schema(description = "Localized description of this field.")
   private List<TextValue> descriptions; // localized description of this field ("Relationship of the person to the head of household").
+
+  @Schema(description = "Localized display labels for the field values.")
   private List<FieldValueDescriptor> values; // localized display labels for the field values
 
   public FieldDescriptor() {

--- a/gedcomx-model/src/main/java/org/gedcomx/records/FieldValue.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/FieldValue.java
@@ -33,6 +33,7 @@ import org.gedcomx.types.ConfidenceLevel;
 import org.gedcomx.types.FieldValueStatusType;
 import org.gedcomx.types.FieldValueType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
@@ -44,19 +45,30 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlType ( name = "FieldValue" )
 @com.webcohesion.enunciate.metadata.Facet( GedcomxConstants.FACET_GEDCOMX_RECORD )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "An element representing a value in a record field.")
 public final class FieldValue extends Conclusion {
 
   /**
    * @see FieldValueType
    */
+  @Schema(description = "The type of the field value.")
   private URI type;
+
+  @Schema(description = "The id of the label applicable to this field value.")
   private String labelId;
+
+  @Schema(description = "The text value.")
   private String text;
+
+  @Schema(description = "The datatype of the text value of the field.")
   private URI datatype;
+
+  @Schema(description = "URI that resolves to the value of the field.")
   private URI resource;
   /**
    * @see FieldValueStatusType
    */
+  @Schema(description = "The status of this FieldValue.")
   private URI status;
 
   public FieldValue() {

--- a/gedcomx-model/src/main/java/org/gedcomx/records/FieldValueDescriptor.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/FieldValueDescriptor.java
@@ -25,6 +25,7 @@ import org.gedcomx.links.HypermediaEnabledData;
 import org.gedcomx.rt.GedcomxConstants;
 import org.gedcomx.types.FieldValueType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
@@ -41,17 +42,37 @@ import java.util.List;
 @XmlType ( name = "FieldValueDescriptor" )
 @com.webcohesion.enunciate.metadata.Facet( GedcomxConstants.FACET_GEDCOMX_RECORD )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A way a field is to be displayed to a user.")
 public class FieldValueDescriptor extends HypermediaEnabledData {
 
+  @Schema(description = "The id of the label applicable to the field value.")
   private String labelId;
+
+  @Schema(description = "The type of the field value.")
   private URI type;
+
+  @Schema(description = "Whether the treatment of the field value is optional. Used to determine whether it should be displayed even if the value is empty.")
   private Boolean optional;
+
+  @Schema(description = "The labels to be used for display purposes.")
   private List<TextValue> displayLabels;
+
+  @Schema(description = "The labels to be used for entry purposes.")
   private List<TextValue> entryLabels;
+
+  @Schema(description = "A sort key for sorting this field value relative to other field values according to how they should be displayed for viewing.")
   private String displaySortKey; // a sort key for sorting the field values by how they should be displayed for viewing
+
+  @Schema(description = "A sort key for sorting this field value relative to other field values according to how they should be entered for editing.")
   private String entrySortKey; // a sort key for sorting the field values by how they should be entered for editing
+
+  @Schema(description = "Whether some kind of entry is required when entering data for editing.")
   private Boolean entryRequired; // whether some kind of entry is required when entering data for editing.
+
+  @Schema(description = "Whether the field value is editable. Some field values might be composed from other field values or otherwise calculated by the system.")
   private Boolean editable; //whether the field value is editable (as opposed to composed from other values by the system).
+
+  @Schema(description = "The id of the label for the \"parent\" field value. For example, the parent field value of a \"given name\" field value might be the \"name\" field value.")
   private String parentLabelId; //the label id of the "parent" field value. E.g. The parent of a "given name" field value might be the "name" field value.
 
   public FieldValueDescriptor() {

--- a/gedcomx-model/src/main/java/org/gedcomx/records/RecordDescriptor.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/RecordDescriptor.java
@@ -24,6 +24,8 @@ import org.gedcomx.rt.GedcomxModelVisitor;
 import org.gedcomx.rt.json.JsonElementWrapper;
 
 import javax.xml.XMLConstants;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
@@ -40,9 +42,13 @@ import java.util.stream.Stream;
 @JsonElementWrapper ( name = "recordDescriptors" )
 @com.webcohesion.enunciate.metadata.Facet( GedcomxConstants.FACET_GEDCOMX_RECORD )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A descriptor for a common set of records.")
 public class RecordDescriptor extends HypermediaEnabledData {
 
+  @Schema(description = "The language of this record description.")
   private String lang;
+
+  @Schema(description = "Descriptors of the fields that are applicable to this record.")
   private List<FieldDescriptor> fields;
 
   public RecordDescriptor() {

--- a/gedcomx-model/src/main/java/org/gedcomx/records/RecordSet.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/records/RecordSet.java
@@ -27,6 +27,8 @@ import org.gedcomx.rt.Model;
 import org.gedcomx.rt.json.JsonElementWrapper;
 
 import javax.xml.XMLConstants;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -60,10 +62,17 @@ import java.util.stream.Stream;
 @XmlType ( name = "RecordSet", propOrder = { "metadata", "records" })
 @com.webcohesion.enunciate.metadata.Facet( GedcomxConstants.FACET_GEDCOMX_RECORD )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "The GEDCOM X bulk record data formats are used to exchange bulk genealogical data sets, grouped into records.")
 public class RecordSet extends HypermediaEnabledData {
 
+  @Schema(description = "The language of this genealogical data set. See http://www.w3.org/International/articles/language-tags/. " +
+      "Note that some language-enabled elements MAY override the language.")
   private String lang;
+
+  @Schema(description = "Metadata about this record set; shared among all records in the set.")
   private Gedcomx metadata;
+
+  @Schema(description = "The records included in this genealogical data set.")
   private List<Gedcomx> records;
 
   public RecordSet() {

--- a/gedcomx-model/src/main/java/org/gedcomx/source/CitationField.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/CitationField.java
@@ -22,6 +22,7 @@ import org.gedcomx.common.URI;
 import org.gedcomx.rt.GedcomxConstants;
 import org.gedcomx.rt.json.HasJsonKey;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
@@ -34,9 +35,13 @@ import jakarta.xml.bind.annotation.XmlValue;
 @XmlType ( name = "CitationField" )
 @Facet ( GedcomxConstants.FACET_GEDCOMX_CITATION )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "Represents a citation field -- its name and value.")
 public class CitationField implements HasJsonKey {
 
+  @Schema(description = "The citation field's name.")
   private URI name;
+
+  @Schema(description = "The citation field's value.")
   private String value;
 
   public CitationField() {

--- a/gedcomx-model/src/main/java/org/gedcomx/source/Coverage.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/Coverage.java
@@ -27,6 +27,7 @@ import org.gedcomx.rt.GedcomxConstants;
 import org.gedcomx.rt.json.JsonElementWrapper;
 import org.gedcomx.types.RecordType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
@@ -40,13 +41,18 @@ import jakarta.xml.bind.annotation.XmlType;
 @JsonElementWrapper ( name = "coverage" )
 @XmlType ( name = "Coverage" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "A description of the coverage of a resource.")
 public class Coverage extends HypermediaEnabledData {
 
+  @Schema(description = "Spatial coverage.")
   private PlaceReference spatial;
+
+  @Schema(description = "Temporal coverage.")
   private Date temporal;
   /**
    * @see org.gedcomx.types.RecordType
    */
+  @Schema(description = "The type of record being covered, if any.")
   private URI recordType;
 
   public Coverage() {

--- a/gedcomx-model/src/main/java/org/gedcomx/source/ReferencesSources.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/ReferencesSources.java
@@ -19,6 +19,7 @@ import org.gedcomx.rt.RDFDomain;
 import org.gedcomx.rt.RDFRange;
 import org.gedcomx.rt.RDFSubPropertyOf;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlType;
 import java.util.List;
 
@@ -29,6 +30,7 @@ import java.util.List;
  * @author Ryan Heaton
  */
 @XmlType ( name = "ReferencesSources" )
+@Schema(description = "Conclusion data that references sources.")
 public interface ReferencesSources {
 
   /**

--- a/gedcomx-model/src/main/java/org/gedcomx/source/SourceCitation.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/SourceCitation.java
@@ -25,6 +25,7 @@ import org.gedcomx.links.Link;
 import org.gedcomx.rt.GedcomxConstants;
 import org.gedcomx.rt.GedcomxModelVisitor;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
@@ -40,11 +41,19 @@ import java.util.Objects;
  */
 @XmlType ( name = "SourceCitation" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "Represents a source citation.")
 public class SourceCitation extends HypermediaEnabledData {
 
+  @Schema(description = "The language of the citation. See http://www.w3.org/International/articles/language-tags/")
   private String lang;
+
+  @Schema(description = "A rendering (as a string) of a source citation.  This rendering should be the most complete rendering available.")
   private String value;
+
+  @Schema(description = "A reference to the citation template for this citation.")
   private ResourceReference citationTemplate;
+
+  @Schema(description = "The list of citation fields.")
   private List<CitationField> fields;
 
   public SourceCitation() {

--- a/gedcomx-model/src/main/java/org/gedcomx/source/SourceCitation.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/SourceCitation.java
@@ -47,7 +47,7 @@ public class SourceCitation extends HypermediaEnabledData {
   @Schema(description = "The language of the citation. See http://www.w3.org/International/articles/language-tags/")
   private String lang;
 
-  @Schema(description = "A rendering (as a string) of a source citation.  This rendering should be the most complete rendering available.")
+  @Schema(description = "A rendering (as a string) of a source citation. This rendering should be the most complete rendering available.")
   private String value;
 
   @Schema(description = "A reference to the citation template for this citation.")

--- a/gedcomx-model/src/main/java/org/gedcomx/source/SourceDescription.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/SourceDescription.java
@@ -57,6 +57,10 @@ import org.gedcomx.types.ResourceStatusType;
 import org.gedcomx.types.ResourceType;
 import org.gedcomx.util.JsonIdentifiers;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.*;
+import javax.xml.XMLConstants;
+import java.util.*;
 
 /**
  * Represents a description of a source.
@@ -65,40 +69,97 @@ import org.gedcomx.util.JsonIdentifiers;
 @XmlType ( name = "SourceDescription", propOrder = {"citations", "mediator", "publisher", "authors", "sources", "analysis", "componentOf", "titles", "titleLabel", "notes", "attribution", "descriptions", "identifiers", "created", "modified", "coverage", "rights", "fields", "repository", "descriptorRef", "replacedBy", "replaces", "statuses"} )
 @JsonElementWrapper ( name = "sourceDescriptions" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "Represents a description of a source.")
 public class SourceDescription extends HypermediaEnabledData implements Attributable, HasNotes, HasFields, ReferencesSources {
 
+  @Schema(description = "The language of this genealogical data set. See http://www.w3.org/International/articles/language-tags/. Note that some language-enabled elements MAY override the language.")
   private String lang;
+
+  @Schema(description = "The preferred bibliographic citation for this source.")
   private List<SourceCitation> citations;
+
+  @Schema(description = "Hint about the media (MIME) type of the resource being described.")
   private String mediaType;
+
+  @Schema(description = "The URI (if applicable) of the actual source.")
   private URI about;
+
+  @Schema(description = "A reference to the entity that mediates access to the described source.")
   private ResourceReference mediator;
+
+  @Schema(description = "A reference to the entity responsible for making the described source available.")
   private ResourceReference publisher;
+
+  @Schema(description = "The authors for this source.")
   private List<URI> authors;
+
+  @Schema(description = "References to any sources to which this source is related (usually applicable to sources that are derived from or contained in another source).")
   private List<SourceReference> sources;
+
+  @Schema(description = "A reference to the analysis document explaining the analysis that went into this description of the source.")
   private ResourceReference analysis;
+
+  @Schema(description = "A reference to the source that contains this source.")
   private SourceReference componentOf;
+
+  @Schema(description = "A list of titles for this source.")
   private List<TextValue> titles;
+
+  @Schema(description = "A label for the title of this description.")
   private TextValue titleLabel;
+
+  @Schema(description = "Notes about a source.")
   private List<Note> notes;
+
+  @Schema(description = "The attribution metadata for this source description.")
   private Attribution attribution;
+
+  @Schema(description = "The type of the resource being described.")
   private URI resourceType;
+
+  @Schema(description = "The rights for this source.")
   private List<URI> rights;
+
+  @Schema(description = "A sort key for this source description.")
   private String sortKey;
+
+  @Schema(description = "A list of descriptions for this source.")
   private List<TextValue> descriptions;
+
+  @Schema(description = "The identifiers for this source.")
   private List<Identifier> identifiers;
+
+  @Schema(description = "The date this source description was created.")
   private Date created;
+
+  @Schema(description = "The date this source description was last modified.")
   private Date modified;
+
+  @Schema(description = "A description of the coverage of a resource.")
   private List<Coverage> coverage;
+
+  @Schema(description = "The fields of the source citation.")
   private List<Field> fields;
+
+  @Schema(description = "A reference to the repository that holds this source.")
   private ResourceReference repository;
+
+  @Schema(description = "A reference to the source description that this source description replaces.")
   private ResourceReference descriptorRef;
+
+  @Schema(description = "A reference to the source description that replaces this source description.")
   private URI replacedBy;
+
+  @Schema(description = "A reference to the source description that this source description replaces.")
   private List<URI> replaces;
+
+  @Schema(description = "The version of this source description.")
   private String version;
 
   /**
    * @see ResourceStatusType
    */
+  @Schema(description = "The status of this source description.")
   private List<URI> statuses;
 
   public SourceDescription() {
@@ -1371,5 +1432,53 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
   @Override
   public String toString() {
     return getId() + ": " + this.resourceType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SourceDescription that = (SourceDescription) o;
+    return Objects.equals(about, that.about) &&
+           Objects.equals(analysis, that.analysis) &&
+           Objects.equals(attribution, that.attribution) &&
+           Objects.equals(authors, that.authors) &&
+           Objects.equals(citations, that.citations) &&
+           Objects.equals(componentOf, that.componentOf) &&
+           Objects.equals(coverage, that.coverage) &&
+           Objects.equals(created, that.created) &&
+           Objects.equals(descriptions, that.descriptions) &&
+           Objects.equals(descriptorRef, that.descriptorRef) &&
+           Objects.equals(fields, that.fields) &&
+           Objects.equals(identifiers, that.identifiers) &&
+           Objects.equals(lang, that.lang) &&
+           Objects.equals(mediaType, that.mediaType) &&
+           Objects.equals(mediator, that.mediator) &&
+           Objects.equals(modified, that.modified) &&
+           Objects.equals(notes, that.notes) &&
+           Objects.equals(publisher, that.publisher) &&
+           Objects.equals(replacedBy, that.replacedBy) &&
+           Objects.equals(replaces, that.replaces) &&
+           Objects.equals(repository, that.repository) &&
+           Objects.equals(resourceType, that.resourceType) &&
+           Objects.equals(rights, that.rights) &&
+           Objects.equals(sortKey, that.sortKey) &&
+           Objects.equals(sources, that.sources) &&
+           Objects.equals(statuses, that.statuses) &&
+           Objects.equals(titleLabel, that.titleLabel) &&
+           Objects.equals(titles, that.titles) &&
+           Objects.equals(version, that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(about, analysis, attribution, authors, citations, componentOf, coverage, created, descriptions,
+                        descriptorRef, fields, identifiers, lang, mediaType, mediator, modified, notes, publisher,
+                        replacedBy, replaces, repository, resourceType, rights, sortKey, sources, statuses,
+                        titleLabel, titles, version);
   }
 }

--- a/gedcomx-model/src/main/java/org/gedcomx/source/SourceDescription.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/SourceDescription.java
@@ -75,7 +75,7 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
   @Schema(description = "The language of this genealogical data set. See http://www.w3.org/International/articles/language-tags/. Note that some language-enabled elements MAY override the language.")
   private String lang;
 
-  @Schema(description = "The preferred bibliographic citation for this source.")
+  @Schema(description = "The bibliographic citation for this source.")
   private List<SourceCitation> citations;
 
   @Schema(description = "Hint about the media (MIME) type of the resource being described.")
@@ -120,40 +120,31 @@ public class SourceDescription extends HypermediaEnabledData implements Attribut
   @Schema(description = "The rights for this source.")
   private List<URI> rights;
 
-  @Schema(description = "A sort key for this source description.")
   private String sortKey;
 
   @Schema(description = "A list of descriptions for this source.")
   private List<TextValue> descriptions;
 
-  @Schema(description = "The identifiers for this source.")
+  @Schema(description = "The list of identifiers for the agent.")
   private List<Identifier> identifiers;
 
-  @Schema(description = "The date this source description was created.")
   private Date created;
 
-  @Schema(description = "The date this source description was last modified.")
   private Date modified;
 
-  @Schema(description = "A description of the coverage of a resource.")
   private List<Coverage> coverage;
 
-  @Schema(description = "The fields of the source citation.")
   private List<Field> fields;
 
-  @Schema(description = "A reference to the repository that holds this source.")
   private ResourceReference repository;
 
-  @Schema(description = "A reference to the source description that this source description replaces.")
   private ResourceReference descriptorRef;
 
-  @Schema(description = "A reference to the source description that replaces this source description.")
   private URI replacedBy;
 
-  @Schema(description = "A reference to the source description that this source description replaces.")
   private List<URI> replaces;
 
-  @Schema(description = "The version of this source description.")
+  @Schema(description = "Gets the version of this resource")
   private String version;
 
   /**

--- a/gedcomx-model/src/main/java/org/gedcomx/source/SourceReference.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/source/SourceReference.java
@@ -26,6 +26,7 @@ import org.gedcomx.links.Link;
 import org.gedcomx.rt.GedcomxModelVisitor;
 import org.gedcomx.rt.json.JsonElementWrapper;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -44,11 +45,19 @@ import java.util.stream.Stream;
 @JsonElementWrapper ( name = "sourceReferences" )
 @XmlType ( name = "SourceReference" )
 @JsonInclude ( JsonInclude.Include.NON_NULL )
+@Schema(description = "An attributable reference to a description of a source.")
 public class SourceReference extends HypermediaEnabledData implements Attributable {
 
+  @Schema(description = "A reference to a description of the source being referenced.")
   private URI descriptionRef;
+
+  @Schema(description = "Id of the source being referenced.")
   private String descriptionId;
+
+  @Schema(description = "The attribution metadata for this source reference.")
   private Attribution attribution;
+
+  @Schema(description = "The qualifiers associated with this source reference.")
   private List<Qualifier> qualifiers;
 
   public SourceReference() {

--- a/gedcomx-model/src/main/java/org/gedcomx/vocab/VocabElement.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/vocab/VocabElement.java
@@ -21,22 +21,41 @@ import org.gedcomx.common.URI;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Representation of a vocabulary element
  */
+@Schema(description = "Representation of a vocabulary element")
 public class VocabElement implements Comparable<VocabElement> {
 
+  @Schema(description = "The id of the element.")
   private String id;
+
+  @Schema(description = "The URI of the element.")
   private URI uri;
+
+  @Schema(description = "The subclass of the element.")
   private URI subclass;
+
+  @Schema(description = "The type of the element.")
   private URI type;
+
+  @Schema(description = "The sort name of the element.")
   private transient String sortName;
+
+  @Schema(description = "The labels of the element.")
   private List<TextValue> labels = new ArrayList<TextValue>();
+
+  @Schema(description = "The descriptions of the element.")
   private List<TextValue> descriptions = new ArrayList<TextValue>();
 
   // This is only present (OPTIONALLY) when used as an "Entries in a List" object
+  @Schema(description = "The sublist of the element.")
   private URI sublist;
+
   // This is only present (OPTIONALLY) when used as an "Entries in a List" object
+  @Schema(description = "The position of the element in the list.")
   private transient Integer position;
 
   public String getId() {

--- a/gedcomx-model/src/main/java/org/gedcomx/vocab/VocabElementList.java
+++ b/gedcomx-model/src/main/java/org/gedcomx/vocab/VocabElementList.java
@@ -20,15 +20,27 @@ import org.gedcomx.common.URI;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Representation of a list of VocabElement objects
  */
+@Schema(description = "Representation of a list of VocabElement objects")
 public class VocabElementList {
 
+  @Schema(description = "The title of the list of elements.")
   private String title;
+
+  @Schema(description = "The description of the list of elements.")
   private String description;
+
+  @Schema(description = "The URI of the list of elements.")
   private URI uri;
+
+  @Schema(description = "The id of the list of elements.")
   private String id;
+
+  @Schema(description = "The list of elements.")
   private List<VocabElement> elements = new ArrayList<VocabElement>();
 
   public String getId() {


### PR DESCRIPTION
Added the swagger @Schema tag to classes and fields to provide descriptive data when creating an openapi.json file in fs-platform-api. This file will then be uploaded to ReadMe.com.