### PR TITLE
Add support for automatic module registration

### DIFF
--- a/gedcomx-rt-support/src/main/java/org/gedcomx/rt/GedcomNamespaceManager.java
+++ b/gedcomx-rt-support/src/main/java/org/gedcomx/rt/GedcomNamespaceManager.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * A nice namespace prefix mapper that can be used to make XML and JSON output as pretty as it can be.
@@ -230,6 +231,15 @@ public class GedcomNamespaceManager extends NamespacePrefixMapper {
   public static Class<?> getWrappedTypeForJsonName(String jsonName) {
     init(Thread.currentThread().getContextClassLoader());
     return WRAPPED_JSON_TYPES_BY_NAME.get(jsonName);
+  }
+
+  /**
+   * Register known JSON types. They must be annotated with either @JsonElementWrapper or @XmlRootElement.
+   *
+   * @param type the types to register.
+   */
+  public static void registerKnownJsonTypes(Class<?>... type) {
+    Stream.of(type).forEach(GedcomNamespaceManager::registerKnownJsonType);
   }
 
   /**

--- a/gedcomx-rt-support/src/main/java/org/gedcomx/rt/json/GedcomJacksonModule.java
+++ b/gedcomx-rt-support/src/main/java/org/gedcomx/rt/json/GedcomJacksonModule.java
@@ -34,7 +34,20 @@ import tools.jackson.databind.ser.Serializers;
 import tools.jackson.databind.type.CollectionType;
 
 /**
- * GEDCOM Jackson module for Jackson customizations.
+ * GEDCOM Jackson module for Jackson customizations. Supports standard GedcomX spec objects when manually or
+ * automatically registered with a Jackson {@link JsonMapper}. If used in conjunction with non-base GedcomX spec
+ * objects, you may have to call
+ * {@link GedcomNamespaceManager#registerKnownJsonType(Class)} or
+ * {@link GedcomNamespaceManager#registerKnownJsonTypes(Class[])} prior to use in order to properly deserialize those
+ * extension objects.
+ * <p>
+ * As an alternative, the {@link #createJsonMapper(Class[])} and
+ * {@link #createJsonMapperBuilder(Class[])} methods will perform class registration for you, prior to returning the
+ * corresponding Jackson mapper object. Some additional configuration is also performed by these methods, such as
+ * enabling pretty printing and excluding null values from serialization.
+ * <p>
+ * Manual module registration can be performed as follows: {@code JsonMapper.builder().addModule(new GedcomJacksonModule()).build()}<br>
+ * Automatic module registration can be performed as follows: {@code JsonMapper.builder().findAndAddModules().build()}.
  *
  * @author Ryan Heaton
  */
@@ -47,10 +60,6 @@ public class GedcomJacksonModule extends JacksonModule {
    * @return The JSON mapper.
    */
   public static JsonMapper createJsonMapper(Class<?>... classes) {
-    for (Class<?> contextClass : classes) {
-      GedcomNamespaceManager.registerKnownJsonType(contextClass);
-    }
-
     return createJsonMapperBuilder(classes).build();
   }
 
@@ -61,9 +70,7 @@ public class GedcomJacksonModule extends JacksonModule {
    * @return The JSON mapper builder.
    */
   public static JsonMapper.Builder createJsonMapperBuilder(Class<?>... classes) {
-    for (Class<?> contextClass : classes) {
-      GedcomNamespaceManager.registerKnownJsonType(contextClass);
-    }
+    GedcomNamespaceManager.registerKnownJsonTypes(classes);
 
     return JsonMapper.builder()
       .annotationIntrospector(new JacksonAnnotationIntrospector())

--- a/gedcomx-rt-support/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
+++ b/gedcomx-rt-support/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
@@ -1,0 +1,17 @@
+#
+# Copyright Intellectual Reserve, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.gedcomx.rt.json.GedcomJacksonModule


### PR DESCRIPTION
Includes documentation updates to better instruct how to use the GedcomJacksonModule class in various scenarios. Adds a convenience method for registering multiple classes with the GedcomNamespaceManager. Removes a duplicate call to said manager when using the createJsonMapper(Class<?>...) method.