### PR TITLE
Remove parent pom reference from bom

### DIFF
--- a/gedcomx-bom/pom.xml
+++ b/gedcomx-bom/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <groupId>org.gedcomx</groupId>
   <artifactId>gedcomx-bom</artifactId>
   <version>4.4.0-SNAPSHOT</version>
   <name>GEDCOM X - BOM</name>
@@ -8,17 +9,12 @@
   <url>https://github.com/FamilySearch/gedcomx-java/gedcomx-bom</url>
   <packaging>pom</packaging>
 
-  <parent>
-    <groupId>org.gedcomx</groupId>
-    <artifactId>gedcomx-parent</artifactId>
-    <version>4.4.0-SNAPSHOT</version>
-  </parent>
-
   <properties>
     <!--we either have to refer to the parent directory (making modules-->
     <!--incapable of building outside the context of the parent) or-->
     <!--we have to duplicate the config files to all modules. Currently-->
     <!--opting for the former.-->
+    <java.compiler.version>17</java.compiler.version>
     <root.basedir>${basedir}/..</root.basedir>
   </properties>
 


### PR DESCRIPTION
Due to the nature of bom pom imports, if a parent pom is specified that includes a dependency management section, those entries are effectively included in the final result as Maven navigates the hierarchy. Prior to this modification, that means importing this bom would also import (and in some cases override other dependency management) for Jackson, JUnit, and more.

The change to remove the parent pom entry from the bom results in only the the dependencies listed in this pom being managed via import.