### PR TITLE
Fix serialization of small objects.

### DIFF
--- a/extensions/familysearch/familysearch-api-model/src/test/java/org/familysearch/platform/TagTest.java
+++ b/extensions/familysearch/familysearch-api-model/src/test/java/org/familysearch/platform/TagTest.java
@@ -1,0 +1,91 @@
+package org.familysearch.platform;
+
+import org.gedcomx.common.URI;
+import org.gedcomx.conclusion.Person;
+import org.gedcomx.rt.json.ExtensibleObjectSerializer;
+import org.gedcomx.rt.json.GedcomJacksonModule;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.ser.SerializationContextExt;
+import tools.jackson.databind.ser.UnrolledBeanSerializer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for Tag JSON serialization (PR #132).
+ *
+ * Tag has only two properties, so Jackson 3 selects UnrolledBeanSerializer for it.
+ * GedcomValueSerializerModifier must handle UnrolledBeanSerializer (not just
+ * BeanSerializer) or Tag will not be wrapped in ExtensibleObjectSerializer.
+ */
+class TagTest {
+
+  @Test
+  void tagUsesUnrolledBeanSerializerPrecondition() {
+    // Confirm Jackson 3 uses UnrolledBeanSerializer for Tag *before* any GedcomX modifier
+    // runs. Use a plain JsonMapper so GedcomValueSerializerModifier doesn't intercept.
+    // If this fails, Jackson changed its threshold and the bug may no longer apply.
+    JsonMapper mapper = JsonMapper.builder().build();
+    SerializationContextExt ctx = mapper._serializationContext();
+    ValueSerializer<Object> ser = ctx.findRootValueSerializer(Tag.class);
+    assertTrue(ser instanceof UnrolledBeanSerializer,
+      "Tag has only 2 properties, so Jackson 3 should select UnrolledBeanSerializer. Actual: " + ser.getClass().getName());
+  }
+
+  @Test
+  void tagSerializerIsWrappedInExtensibleObjectSerializer() {
+    // GedcomValueSerializerModifier must wrap Tag's serializer in ExtensibleObjectSerializer.
+    // Before PR #132, only BeanSerializer was intercepted; UnrolledBeanSerializer was returned
+    // as-is, bypassing the GedcomX extension mechanism.
+    JsonMapper mapper = GedcomJacksonModule.createJsonMapper(Tag.class);
+    SerializationContextExt ctx = mapper._serializationContext();
+    ValueSerializer<Object> ser = ctx.findRootValueSerializer(Tag.class);
+    assertTrue(ser instanceof ExtensibleObjectSerializer,
+      "Tag's serializer must be wrapped in ExtensibleObjectSerializer. Actual: " + ser.getClass().getName());
+  }
+
+  @Test
+  void tagSerializesAsExtensionElementOnPerson() throws Exception {
+    // Integration test: Tag embedded as an extension element in a Person serializes
+    // and round-trips correctly through JSON.
+    JsonMapper mapper = GedcomJacksonModule.createJsonMapper(Tag.class);
+
+    Tag tag = new Tag();
+    tag.setResource(URI.create("http://gedcomx.org/Birth"));
+
+    Person person = new Person();
+    person.setId("P-1");
+    person.addExtensionElement(tag);
+
+    FamilySearchPlatform fsp = new FamilySearchPlatform();
+    fsp.addPerson(person);
+
+    String json = mapper.writeValueAsString(fsp);
+    assertNotNull(json);
+    assertTrue(json.contains("tags"), "Serialized JSON should contain 'tags' array");
+    assertTrue(json.contains("http://gedcomx.org/Birth"), "Serialized JSON should contain the tag resource URI");
+
+    FamilySearchPlatform roundTripped = mapper.readValue(json, FamilySearchPlatform.class);
+    assertNotNull(roundTripped);
+    assertNotNull(roundTripped.getPerson());
+  }
+
+  @Test
+  void tagWithConclusionIdSerializesAsExtensionElement() throws Exception {
+    JsonMapper mapper = GedcomJacksonModule.createJsonMapper(Tag.class);
+
+    Tag tag = new Tag("CONC-001");
+
+    Person person = new Person();
+    person.setId("P-1");
+    person.addExtensionElement(tag);
+
+    FamilySearchPlatform fsp = new FamilySearchPlatform();
+    fsp.addPerson(person);
+
+    String json = mapper.writeValueAsString(fsp);
+    assertNotNull(json);
+    assertTrue(json.contains("CONC-001"), "Serialized JSON should contain the conclusionId");
+  }
+}

--- a/gedcomx-rt-support/src/main/java/org/gedcomx/rt/json/GedcomValueSerializerModifier.java
+++ b/gedcomx-rt-support/src/main/java/org/gedcomx/rt/json/GedcomValueSerializerModifier.java
@@ -19,7 +19,9 @@ import tools.jackson.databind.BeanDescription;
 import tools.jackson.databind.SerializationConfig;
 import tools.jackson.databind.ValueSerializer;
 import tools.jackson.databind.ser.BeanSerializer;
+import tools.jackson.databind.ser.UnrolledBeanSerializer;
 import tools.jackson.databind.ser.ValueSerializerModifier;
+import tools.jackson.databind.ser.bean.BeanSerializerBase;
 
 /**
  * Modifications for GEDCOM value serializers.
@@ -34,9 +36,35 @@ public class GedcomValueSerializerModifier extends ValueSerializerModifier {
     BeanDescription.Supplier beanDescRef,
     ValueSerializer<?> serializer) {
 
+    if (serializer instanceof UnrolledBeanSerializer) {
+      serializer = new PublicBeanSerializer((BeanSerializerBase) serializer);
+    }
+
     return serializer instanceof BeanSerializer beanSerializer ?
       new ExtensibleObjectSerializer(beanSerializer) :
       serializer;
+  }
+
+  /**
+   * Public wrapper around BeanSerializer to expose the protected constructor.
+   *
+   * BeanSerializer has a protected constructor that accepts BeanSerializerBase,
+   * which is needed to replace UnrolledBeanSerializer. This subclass makes that
+   * constructor accessible.
+   */
+  private static class PublicBeanSerializer extends BeanSerializer {
+    /**
+     * Constructs a BeanSerializer from an existing BeanSerializerBase.
+     * <p>
+     * This constructor delegates to the protected BeanSerializer(BeanSerializerBase)
+     * constructor, allowing us to convert UnrolledBeanSerializer instances to
+     * standard BeanSerializer instances.
+     *
+     * @param src the source serializer (typically an UnrolledBeanSerializer)
+     */
+    public PublicBeanSerializer(BeanSerializerBase src) {
+      super(src);
+    }
   }
 
 }

--- a/gedcomx-rt-support/src/test/java/org/gedcomx/rt/json/GedcomValueSerializerModifierTest.java
+++ b/gedcomx-rt-support/src/test/java/org/gedcomx/rt/json/GedcomValueSerializerModifierTest.java
@@ -1,0 +1,82 @@
+package org.gedcomx.rt.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.ser.SerializationContextExt;
+import tools.jackson.databind.ser.UnrolledBeanSerializer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for GedcomValueSerializerModifier (PR #132).
+ *
+ * Jackson 3 selects UnrolledBeanSerializer for classes with few bean properties
+ * (up to 6). GedcomValueSerializerModifier.modifySerializer() must handle
+ * UnrolledBeanSerializer in addition to BeanSerializer, or small objects
+ * like Tag will not be wrapped in ExtensibleObjectSerializer.
+ */
+class GedcomValueSerializerModifierTest {
+
+  /**
+   * A minimal two-property bean that Jackson 3 will serialize using
+   * UnrolledBeanSerializer (the small-object fast path, up to 6 props).
+   */
+  @XmlRootElement
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  static class SmallBean {
+    private String value1;
+    private String value2;
+
+    public String getValue1() { return value1; }
+    public void setValue1(String v) { value1 = v; }
+    public String getValue2() { return value2; }
+    public void setValue2(String v) { value2 = v; }
+  }
+
+  @Test
+  void smallObjectUsesUnrolledBeanSerializer() {
+    // Verify the precondition: Jackson 3 selects UnrolledBeanSerializer for small
+    // beans *before* any GedcomX module modifier runs. Use a plain JsonMapper so
+    // GedcomValueSerializerModifier doesn't intercept the result. If this fails,
+    // Jackson changed its selection strategy and the other tests may need updating.
+    JsonMapper mapper = JsonMapper.builder().build();
+    SerializationContextExt ctx = mapper._serializationContext();
+    ValueSerializer<Object> ser = ctx.findRootValueSerializer(SmallBean.class);
+    assertTrue(ser instanceof UnrolledBeanSerializer,
+      "Jackson 3 should select UnrolledBeanSerializer for small beans. Actual: " + ser.getClass().getName());
+  }
+
+  @Test
+  void modifySerializerWrapsUnrolledBeanSerializer() {
+    // GedcomValueSerializerModifier must convert UnrolledBeanSerializer into
+    // ExtensibleObjectSerializer so that extension elements/attributes are handled.
+    // Without the fix in PR #132, only BeanSerializer instances were intercepted,
+    // leaving UnrolledBeanSerializer (used for Tag and other small objects) unwrapped.
+    JsonMapper mapper = GedcomJacksonModule.createJsonMapper(SmallBean.class);
+    SerializationContextExt ctx = mapper._serializationContext();
+    ValueSerializer<Object> ser = ctx.findRootValueSerializer(SmallBean.class);
+    assertTrue(ser instanceof ExtensibleObjectSerializer,
+      "GedcomValueSerializerModifier must wrap UnrolledBeanSerializer in ExtensibleObjectSerializer. " +
+      "Actual: " + ser.getClass().getName());
+  }
+
+  @Test
+  void smallBeanSerializesCorrectly() throws Exception {
+    JsonMapper mapper = GedcomJacksonModule.createJsonMapper(SmallBean.class);
+
+    SmallBean bean = new SmallBean();
+    bean.setValue1("hello");
+    bean.setValue2("world");
+
+    String json = mapper.writeValueAsString(bean);
+    assertNotNull(json);
+
+    JsonNode node = mapper.readTree(json);
+    assertEquals("hello", node.get("value1").asText());
+    assertEquals("world", node.get("value2").asText());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <commons-codec.version>1.20.0</commons-codec.version>
     <enunciate.version>2.19.0</enunciate.version>
     <hamcrest.version>3.0</hamcrest.version>
-    <jackson.version>3.0.2</jackson.version>
+    <jackson.version>3.1.3</jackson.version>
     <jackson.jaxrs.version>2.20.1</jackson.jaxrs.version>
     <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
     <jakarta.xml.bind-api.version>4.0.4</jakarta.xml.bind-api.version>


### PR DESCRIPTION
Jackson 3 introduced an UnrolledBeanSerializer class which it uses to serialize small object for performance reasons. For some reason, that serializer doesn't work for GedcomX. Specifically, it can't serialize Tag.java (which only has two attributes). This change replaces UnrolledSBeanSerializer with PublicBeanSerializer to fix the problem.